### PR TITLE
Sessão 1: correções triviais de frontend (#5, #20, #21, #13)

### DIFF
--- a/static/js/lote-selecao.js
+++ b/static/js/lote-selecao.js
@@ -8,6 +8,9 @@ function initSelecaoLote({ onCheck, onUncheck } = {}) {
   const btnConfirmar = document.getElementById('btn-confirmar');
   const contagemTxt  = document.getElementById('contagem-txt');
 
+  let selecionados = 0;
+  checks.forEach(chk => { if (chk.checked) selecionados++; });
+
   function toggleAnimal(checkbox) {
     const id  = checkbox.value;
     const row = checkbox.closest('tr');
@@ -16,12 +19,14 @@ function initSelecaoLote({ onCheck, onUncheck } = {}) {
     const hid = document.getElementById('hid-' + id);
 
     if (checkbox.checked) {
+      selecionados++;
       row.classList.add('selecionado');
       pw.classList.add('visivel');
       inp.disabled = false;
       hid.disabled = false;
       if (onCheck) onCheck(id, inp);
     } else {
+      selecionados--;
       row.classList.remove('selecionado');
       pw.classList.remove('visivel');
       inp.disabled = true;
@@ -32,7 +37,6 @@ function initSelecaoLote({ onCheck, onUncheck } = {}) {
   }
 
   function atualizarEstado() {
-    const selecionados = document.querySelectorAll('.animal-check:checked').length;
     contagemTxt.textContent = selecionados + ' selecionado(s)';
     btnConfirmar.disabled = selecionados === 0;
     marcarTodos.indeterminate = selecionados > 0 && selecionados < checks.length;
@@ -46,8 +50,10 @@ function initSelecaoLote({ onCheck, onUncheck } = {}) {
   marcarTodos.addEventListener('change', function () {
     const marcarTudo = this.checked;
     checks.forEach(chk => {
-      chk.checked = marcarTudo;
-      toggleAnimal(chk);
+      if (chk.checked !== marcarTudo) {
+        chk.checked = marcarTudo;
+        toggleAnimal(chk);
+      }
     });
   });
 

--- a/templates/animal_progenie.html
+++ b/templates/animal_progenie.html
@@ -97,7 +97,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.simple.min.js"></script>
 {% if filhos %}
 {% set filhos_com_gmd = filhos | selectattr(4, 'ne', none) | list %}
 {% if filhos_com_gmd | length >= 2 %}

--- a/templates/detalhes.html
+++ b/templates/detalhes.html
@@ -318,7 +318,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.simple.min.js"></script>
 {% if animal and historico_peso | length >= 2 %}
 <script>
 const pesagensRaw = [

--- a/templates/estoque_lista.html
+++ b/templates/estoque_lista.html
@@ -218,7 +218,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.simple.min.js"></script>
 {% if produtos %}
 <script>
 const estoqueItems = [

--- a/templates/financeiro.html
+++ b/templates/financeiro.html
@@ -290,7 +290,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.simple.min.js"></script>
 {% if financeiro.entradas_ano != 0 or financeiro.saidas_ano != 0 %}
 <script>
 function parseVal(str) {

--- a/templates/graficos.html
+++ b/templates/graficos.html
@@ -214,12 +214,11 @@ function carregarDados() {
   instPeso.showLoading({ text: 'Carregando...', color: '#3B6D11' });
 
   Promise.all([
-    fetch("{{ url_for('api.graficos_sexo') }}").then(r => r.json()),
-    fetch("{{ url_for('api.graficos_peso') }}").then(r => r.json()),
-    fetch("{{ url_for('api.graficos_gmd') }}").then(r => r.json())
-  ]).then(([sexo, peso, gmdData]) => {
-    if (sexo.error || peso.error || gmdData.error) throw new Error('API error');
-    dadosGlobais = { sexo, peso, gmd_medio: gmdData.gmd_medio };
+    fetch("{{ url_for('api.dashboard_summary') }}").then(r => r.json()),
+    fetch("{{ url_for('api.graficos_peso') }}").then(r => r.json())
+  ]).then(([summary, peso]) => {
+    if (summary.error || peso.error) throw new Error('API error');
+    dadosGlobais = { sexo: summary.sexo, peso, gmd_medio: summary.gmd.gmd_medio };
     localStorage.setItem(CACHE_KEY, JSON.stringify({ timestamp: Date.now(), dados: dadosGlobais }));
     instSexo.hideLoading();
     instPeso.hideLoading();

--- a/templates/index.html
+++ b/templates/index.html
@@ -169,7 +169,8 @@
 </form>
 
 <!-- ── Filtros de status ───────────────────────────────── -->
-<div class="flex flex-wrap items-center gap-2" style="margin-bottom:var(--space-5);">
+<div class="flex items-start gap-2" style="margin-bottom:var(--space-5);">
+<div class="flex flex-wrap items-center gap-2" style="row-gap:var(--space-2);">
   <span class="label" id="status-tabs-label">Exibir:</span>
   <div role="tablist" aria-labelledby="status-tabs-label" style="display:contents;">
     <a href="{{ url_for('operacional.painel', status='todos',    busca=busca, raca=raca_filtro, origem=origem_filtro, sexo=sexo_filtro) }}"
@@ -209,8 +210,9 @@
      class="btn btn-sm btn-secondary{% if raca_filtro == r %} is-active{% endif %}">{{ r }}</a>
   {% endfor %}
   {% endif %}
+</div>
   <a href="{{ url_for('operacional.lixeira') }}"
-     class="btn btn-sm btn-ghost" style="margin-left:auto;">
+     class="btn btn-sm btn-ghost" style="margin-left:auto; flex-shrink:0;">
     <svg aria-hidden="true" class="icon icon-sm" viewBox="0 0 24 24"><path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6"/><path d="M10 11v6M14 11v6"/></svg>
     Lixeira
   </a>

--- a/templates/pastos_gmd.html
+++ b/templates/pastos_gmd.html
@@ -65,7 +65,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.simple.min.js"></script>
 {% if ranking %}
 <script>
 const ranking = [

--- a/templates/ranking_touros.html
+++ b/templates/ranking_touros.html
@@ -113,7 +113,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.simple.min.js"></script>
 {% if ranking %}
 <script>
 const gmdRebanho = {{ gmd_medio }};


### PR DESCRIPTION
## Sumário
- Corrige quebra de linha fora do padrão do botão Lixeira na barra de filtros do painel (#5)
- Troca `echarts.min.js` (~1MB) por `echarts.simple.min.js` (~470KB) em 6 templates que não usam os chart types exclusivos do build completo (#20)
- Substitui recontagem O(n²) por contador incremental em `lote-selecao.js` (#21)
- `graficos.html` passa a usar `/api/dashboard-summary` em vez de 2 dos 3 fetches redundantes (#13)

Closes #5
Closes #20
Closes #21
Closes #13

## Test plan
- [x] `pytest tests/` — 271 passed
- [ ] Conferir visualmente a barra de filtros do painel quebrando em 2 linhas (viewport estreito)
- [ ] Conferir os 6 gráficos afetados por #20 renderizando normalmente
- [ ] Testar marcar/desmarcar todos em pesagem em lote e venda em lote