### PR TITLE
Sessão 2: rede de segurança de infra/DB (#11, #17)

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -4,6 +4,7 @@ DB_PORT=        # porta padrão MySQL é 3306
 DB_USER=        # usuário do banco
 DB_NAME=        # nome do banco de dados
 DB_PASSWORD=    # senha do banco
+DB_POOL_SIZE=   # tamanho do pool de conexões, default 5
 
 # Segurança
 SECRET_KEY=     # chave secreta Flask — gere com: python -c "import secrets; print(secrets.token_hex(32))"

--- a/db_config.py
+++ b/db_config.py
@@ -25,7 +25,7 @@ connection_pool = None
 
 try:
     connection_pool = mysql.connector.pooling.MySQLConnectionPool(
-        pool_name="gado_pool", pool_size=5, **db_settings
+        pool_name="gado_pool", pool_size=int(os.getenv('DB_POOL_SIZE', 5)), **db_settings
     )
     logger.info(" Modo Rápido (Pool) ativado!")
 except Error as e:

--- a/init_db.py
+++ b/init_db.py
@@ -234,6 +234,9 @@ def criar_schema(cursor):
         ("idx_animais_lote",        "CREATE INDEX idx_animais_lote ON animais (lote_id, deleted_at)"),
         # inclui deleted_at para cobrir v_fluxo_caixa após condition pushdown do MySQL 8.0.22+
         ("idx_custos_user_del_data", "CREATE INDEX idx_custos_user_del_data ON custos_operacionais (user_id, deleted_at, data_custo)"),
+        # animais.pai_id/mae_id sem índice — cobre full scan em queries de pedigree/reprodução
+        ("idx_animais_pai",          "CREATE INDEX idx_animais_pai ON animais (pai_id)"),
+        ("idx_animais_mae",          "CREATE INDEX idx_animais_mae ON animais (mae_id)"),
     ]
 
     for nome_idx, sql in indices_sql:


### PR DESCRIPTION
## Sumário
- Pool de conexões MySQL configurável via `DB_POOL_SIZE` (default 5) em vez de hardcoded (#11)
- Índices em `animais.pai_id` e `animais.mae_id`, que hoje causam full scan em queries de pedigree/reprodução (#17)

Closes #11
Closes #17

## Test plan
- [x] `pytest tests/` — 271 passed (conftest roda `init_db.criar_schema`, exercitando os novos índices)