### PR TITLE
Sessão 3: filtro de origem no widget de GMD e nos cards do painel (#7, #8)

### DIFF
--- a/repositories/animal_repository.py
+++ b/repositories/animal_repository.py
@@ -601,11 +601,13 @@ def get_medicacoes_by_animal(animal_id):
 
 # ---- GRAFICOS ----
 
-def get_contagem_por_sexo(user_id):
+def get_contagem_por_sexo(user_id, origem=None):
+    origem_cond = _origem_cond(origem, alias='')
     with get_db_cursor() as cursor:
         cursor.execute(
             "SELECT sexo, COUNT(*) FROM animais "
             "WHERE user_id = %s AND data_venda IS NULL AND deleted_at IS NULL "
+            f"{origem_cond} "
             "GROUP BY sexo",
             (user_id,)
         )

--- a/repositories/animal_repository.py
+++ b/repositories/animal_repository.py
@@ -31,6 +31,14 @@ def _build_animais_where(user_id, termo=None, status='todos', na_lixeira=False, 
     return "WHERE " + " AND ".join(conds), params
 
 
+def _origem_cond(origem, alias='a.'):
+    """Mesma condição de 'nascido na fazenda' usada em _build_animais_where, para
+    as CTEs de GMD que montam o JOIN com animais manualmente."""
+    if origem == 'fazenda':
+        return f" AND {alias}data_compra IS NULL AND {alias}data_nascimento IS NOT NULL"
+    return ""
+
+
 # ---- LISTAGENS E CONTAGENS ----
 
 def count_animais(user_id, termo=None, status='todos', raca=None, origem=None, sexo=None):
@@ -293,15 +301,18 @@ def get_gmd_by_animal(animal_id):
         return cursor.fetchone()
 
 
-def get_gmd_medio_rebanho(user_id, sexo=None):
+def get_gmd_medio_rebanho(user_id, sexo=None, origem=None):
     """AVG do GMD calculado diretamente sobre pesagens — sem materializar v_gmd_analitico.
 
     Filtra user_id no JOIN com animais antes das window functions, evitando
     que o MySQL varra pesagens de todos os usuários antes de restringir ao tenant.
     `sexo` ('M'/'F') restringe o rebanho considerado no cálculo — usado para
     segregar matrizes (GMD baixo por natureza) do restante do plantel.
+    `origem='fazenda'` restringe aos animais nascidos na própria fazenda,
+    mesmo filtro de origem aplicado à listagem via _build_animais_where.
     """
     sexo_cond = " AND a.sexo = %s" if sexo in ('M', 'F') else ""
+    origem_cond = _origem_cond(origem)
     params = [user_id] + ([sexo] if sexo in ('M', 'F') else [])
     with get_db_cursor() as cursor:
         cursor.execute(
@@ -313,7 +324,7 @@ def get_gmd_medio_rebanho(user_id, sexo=None):
             "  JOIN animais a ON a.id = p.animal_id"
             "    AND a.user_id = %s AND a.deleted_at IS NULL AND a.data_venda IS NULL"
             "    AND p.deleted_at IS NULL"
-            f"    {sexo_cond}"
+            f"    {sexo_cond}{origem_cond}"
             "),"
             " pu AS ("
             "  SELECT animal_id,"
@@ -372,14 +383,16 @@ def get_animais_com_gmd(user_id):
         return cursor.fetchall()
 
 
-def get_animais_abaixo_gmd_medio(user_id, sexo=None):
+def get_animais_abaixo_gmd_medio(user_id, sexo=None, origem=None):
     """Animais ativos com GMD abaixo de (média - 2σ): outliers estatísticos do rebanho.
 
     `sexo` ('M'/'F') restringe o grupo usado para calcular média/desvio — mesma
     segregação de get_gmd_medio_rebanho, necessária para o dashboard não misturar
     as duas fontes de gmd_medio conforme existam ou não outliers.
+    `origem='fazenda'` aplica o mesmo filtro de origem de get_gmd_medio_rebanho.
     """
     sexo_cond = " AND a.sexo = %s" if sexo in ('M', 'F') else ""
+    origem_cond = _origem_cond(origem)
     params = [user_id] + ([sexo] if sexo in ('M', 'F') else [])
     with get_db_cursor() as cursor:
         cursor.execute(
@@ -391,7 +404,7 @@ def get_animais_abaixo_gmd_medio(user_id, sexo=None):
             "  JOIN animais a ON a.id = p.animal_id"
             "    AND a.user_id = %s AND a.deleted_at IS NULL AND a.data_venda IS NULL"
             "    AND p.deleted_at IS NULL"
-            f"    {sexo_cond}"
+            f"    {sexo_cond}{origem_cond}"
             "),"
             " pu AS ("
             "  SELECT animal_id,"

--- a/routes/api.py
+++ b/routes/api.py
@@ -199,17 +199,18 @@ def dashboard_summary():
     """Retorna sexo + GMD + alertas em uma única request — 2 queries vs 3 antes."""
     uid = current_user.id
     sexo_filtro = request.args.get('sexo') if request.args.get('sexo') in ('M', 'F') else None
+    origem_filtro = request.args.get('origem') if request.args.get('origem') == 'fazenda' else None
     rows_sexo = animal_repository.get_contagem_por_sexo(uid)
     sexo = {s: q for s, q in rows_sexo}
 
-    rows_alertas = animal_repository.get_animais_abaixo_gmd_medio(uid, sexo=sexo_filtro)
+    rows_alertas = animal_repository.get_animais_abaixo_gmd_medio(uid, sexo=sexo_filtro, origem=origem_filtro)
 
     if rows_alertas:
         gmd_medio  = round(float(rows_alertas[0][3]), 3)
         limite     = round(float(rows_alertas[0][5]), 3)
         alertas    = [{'id': r[0], 'brinco': r[1], 'gmd_atual': round(float(r[2]), 3)} for r in rows_alertas]
     else:
-        gmd_medio = round(animal_repository.get_gmd_medio_rebanho(uid, sexo=sexo_filtro), 3)
+        gmd_medio = round(animal_repository.get_gmd_medio_rebanho(uid, sexo=sexo_filtro, origem=origem_filtro), 3)
         limite    = None
         alertas   = []
 

--- a/routes/api.py
+++ b/routes/api.py
@@ -200,7 +200,7 @@ def dashboard_summary():
     uid = current_user.id
     sexo_filtro = request.args.get('sexo') if request.args.get('sexo') in ('M', 'F') else None
     origem_filtro = request.args.get('origem') if request.args.get('origem') == 'fazenda' else None
-    rows_sexo = animal_repository.get_contagem_por_sexo(uid)
+    rows_sexo = animal_repository.get_contagem_por_sexo(uid, origem=origem_filtro)
     sexo = {s: q for s, q in rows_sexo}
 
     rows_alertas = animal_repository.get_animais_abaixo_gmd_medio(uid, sexo=sexo_filtro, origem=origem_filtro)

--- a/templates/index.html
+++ b/templates/index.html
@@ -319,7 +319,7 @@ document.querySelectorAll('[role="tab"]').forEach(function(tab) {
 </script>
 <script>
 const API = {
-  summary: "{{ url_for('api.dashboard_summary', sexo=sexo_filtro) }}",
+  summary: "{{ url_for('api.dashboard_summary', sexo=sexo_filtro, origem=origem_filtro) }}",
   cotacao: "{{ url_for('api.cotacoes_regionais') }}",
   brasil:  "{{ url_for('api.cotacoes_brasil') }}",
   pdf:     "{{ url_for('api.relatorio_pdf') }}",

--- a/templates/index.html
+++ b/templates/index.html
@@ -85,7 +85,7 @@
 
   <div class="metric-card">
     <span class="label skeleton skeleton-label" aria-hidden="true" id="sk-lbl-total"></span>
-    <span class="label" id="lbl-total" style="display:none;">Total no rebanho</span>
+    <span class="label" id="lbl-total" style="display:none;">Total no Rebanho{% if origem_filtro == 'fazenda' %} Filtrado{% endif %}</span>
     <div class="metric-value" id="val-total" aria-live="polite" aria-atomic="true">
       <span class="skeleton skeleton-value" aria-hidden="true" id="sk-total"></span>
     </div>

--- a/tests/test_origem_fazenda.py
+++ b/tests/test_origem_fazenda.py
@@ -160,6 +160,14 @@ def test_get_gmd_medio_rebanho_origem_fazenda_filtra(um):
     assert gmd_geral == pytest.approx(0.75)
 
 
+def test_get_contagem_por_sexo_origem_fazenda_filtra(um):
+    _make_animal_comprado(um)  # sexo M
+    _make_animal_nascido_fazenda(um)  # sexo F
+
+    contagem = dict(animal_repository.get_contagem_por_sexo(um, origem='fazenda'))
+    assert contagem == {'F': 1}
+
+
 # ── rota ─────────────────────────────────────────────────────────────────────
 
 def test_rota_painel_origem_fazenda(app):
@@ -173,5 +181,25 @@ def test_rota_painel_origem_fazenda(app):
             assert r.status_code == 200
             assert b"ROTANASC" in r.data
             assert b"ROTACOMP" not in r.data
+    finally:
+        _purge(uid)
+
+
+def test_dashboard_summary_origem_fazenda(app):
+    uid = _make_user()
+    comprado = _make_animal_comprado(uid)
+    nascido = _make_animal_nascido_fazenda(uid)
+    _add_pesagem(comprado, '2024-01-01', 200)
+    _add_pesagem(comprado, '2024-01-11', 210)  # gmd 1.0
+    _add_pesagem(nascido, '2024-02-01', 100)
+    _add_pesagem(nascido, '2024-02-11', 105)   # gmd 0.5
+    try:
+        with app.test_client() as client:
+            _login(client, uid)
+            r = client.get("/api/dashboard-summary?origem=fazenda")
+            assert r.status_code == 200
+            data = r.get_json()
+            assert data['sexo'] == {'F': 1}
+            assert data['gmd']['gmd_medio'] == pytest.approx(0.5)
     finally:
         _purge(uid)

--- a/tests/test_origem_fazenda.py
+++ b/tests/test_origem_fazenda.py
@@ -63,6 +63,16 @@ def _make_animal_nascido_fazenda(user_id, brinco=None, vendido=False):
     return aid
 
 
+def _add_pesagem(animal_id, data, peso):
+    conn = dbc.get_db_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO pesagens (animal_id, data_pesagem, peso) VALUES (%s, %s, %s)",
+        (animal_id, data, peso),
+    )
+    conn.commit(); cur.close(); conn.close()
+
+
 def _purge(user_id):
     conn = dbc.get_db_connection()
     cur = conn.cursor()
@@ -133,6 +143,21 @@ def test_origem_sem_filtro_retorna_todos(um):
     animais = animal_repository.get_animais_paginados(um, 20, 0)
     ids = {a[0] for a in animais}
     assert {comprado, nascido}.issubset(ids)
+
+
+def test_get_gmd_medio_rebanho_origem_fazenda_filtra(um):
+    comprado = _make_animal_comprado(um)
+    nascido = _make_animal_nascido_fazenda(um)
+    _add_pesagem(comprado, '2024-01-01', 200)
+    _add_pesagem(comprado, '2024-01-11', 210)  # gmd 1.0
+    _add_pesagem(nascido, '2024-02-01', 100)
+    _add_pesagem(nascido, '2024-02-11', 105)   # gmd 0.5
+
+    gmd_fazenda = animal_repository.get_gmd_medio_rebanho(um, origem='fazenda')
+    gmd_geral = animal_repository.get_gmd_medio_rebanho(um)
+
+    assert gmd_fazenda == pytest.approx(0.5)
+    assert gmd_geral == pytest.approx(0.75)
 
 
 # ── rota ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Sumário
- Widget de GMD médio (e o de outliers abaixo da média) agora respeita `origem=fazenda`, não só `sexo` — a causa raiz era `get_gmd_medio_rebanho`/`get_animais_abaixo_gmd_medio` não aceitarem esse parâmetro (#7)
- Mesma correção estendida aos cards "Total no Rebanho", "Machos" e "Fêmeas" via `get_contagem_por_sexo(origem=...)`; label muda para "Total no Rebanho Filtrado" quando o filtro está ativo (#8)

Closes #7
Closes #8

## Test plan
- [x] `pytest tests/` — 274 passed (4 testes novos: GMD e contagem por sexo filtrados por origem, no nível de repositório e de rota `/api/dashboard-summary`)
- [ ] Conferir visualmente painel com "Nascidos na Fazenda" + "Machos" ativos e comparar GMD exibido com o de "Machos" sem o filtro