### PR TITLE
Sessão 4: queries redundantes (#19, #14)

### DIFF
--- a/routes/api.py
+++ b/routes/api.py
@@ -232,7 +232,8 @@ def relatorio_pdf():
     config    = configuracao_repository.get_configuracao(current_user.id)
     fluxo     = financeiro_repository.get_fluxo_caixa(current_user.id)
     animais   = animal_repository.get_animais_com_gmd(current_user.id)
-    gmd_medio = animal_repository.get_gmd_medio_rebanho(current_user.id)
+    gmds      = [float(a[5]) for a in animais if a[5] is not None]
+    gmd_medio = sum(gmds) / len(gmds) if gmds else 0.0
 
     html = render_template('relatorio_pdf.html',
                            config=config, fluxo=fluxo, animais=animais,

--- a/tests/test_alertas.py
+++ b/tests/test_alertas.py
@@ -92,3 +92,50 @@ def test_verificar_contas_chama_send_quando_ha_dados(app, db_setup):
     cur2.execute("DELETE FROM financial_schedule WHERE user_id=%s", (uid,))
     cur2.execute("DELETE FROM usuarios WHERE id=%s", (uid,))
     conn2.commit(); cur2.close(); conn2.close()
+
+
+def test_verificar_contas_vencendo_agrupa_por_usuario(app, db_setup):
+    """A query agrupada não deve misturar as contas de usuários diferentes."""
+    import itertools
+    from werkzeug.security import generate_password_hash
+    import db_config as dbc
+
+    seq = itertools.count(89000)
+    n1, n2 = next(seq), next(seq)
+    conn = dbc.get_db_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO usuarios (username, password_hash, email) VALUES (%s, %s, %s)",
+        (f"alerta_u{n1}", generate_password_hash("x"), f"alerta{n1}@test.com")
+    )
+    uid1 = cur.lastrowid
+    cur.execute(
+        "INSERT INTO usuarios (username, password_hash, email) VALUES (%s, %s, %s)",
+        (f"alerta_u{n2}", generate_password_hash("x"), f"alerta{n2}@test.com")
+    )
+    uid2 = cur.lastrowid
+    cur.execute(
+        "INSERT INTO financial_schedule (user_id, descricao, valor, vencimento, status) "
+        "VALUES (%s, 'Ração', 2000.00, CURDATE(), 'pendente')",
+        (uid1,)
+    )
+    cur.execute(
+        "INSERT INTO financial_schedule (user_id, descricao, valor, vencimento, status) "
+        "VALUES (%s, 'Sal Mineral', 500.00, CURDATE(), 'pendente')",
+        (uid2,)
+    )
+    conn.commit(); cur.close(); conn.close()
+
+    with patch('utils.email_service.send_alert_contas') as mock_send:
+        from utils.alertas import verificar_contas_vencendo
+        verificar_contas_vencendo(app)
+        assert mock_send.call_count == 2
+        chamadas = {c.args[0]: c.args[1] for c in mock_send.call_args_list}
+        assert chamadas[f"alerta{n1}@test.com"][0][0] == 'Ração'
+        assert chamadas[f"alerta{n2}@test.com"][0][0] == 'Sal Mineral'
+
+    conn2 = dbc.get_db_connection()
+    cur2 = conn2.cursor()
+    cur2.execute("DELETE FROM financial_schedule WHERE user_id IN (%s, %s)", (uid1, uid2))
+    cur2.execute("DELETE FROM usuarios WHERE id IN (%s, %s)", (uid1, uid2))
+    conn2.commit(); cur2.close(); conn2.close()

--- a/utils/alertas.py
+++ b/utils/alertas.py
@@ -1,32 +1,44 @@
 import logging
+from collections import defaultdict
 from db_config import get_db_cursor
 
 logger = logging.getLogger(__name__)
 
 
-def _get_usuarios_com_email():
-    with get_db_cursor() as cursor:
-        cursor.execute("SELECT id, email FROM usuarios WHERE email IS NOT NULL AND email != ''")
-        return cursor.fetchall()
+def _agrupar_por_usuario(rows):
+    """rows: [(user_id, email, *dados)] -> [(email, [dados, ...]), ...] preservando ordem.
+
+    Agrupa por user_id (não por email) — email não tem UNIQUE constraint em
+    usuarios, então duas contas poderiam compartilhar o mesmo endereço.
+    """
+    dados_por_uid = defaultdict(list)
+    email_por_uid = {}
+    ordem_uids = []
+    for user_id, email, *dados in rows:
+        if user_id not in email_por_uid:
+            ordem_uids.append(user_id)
+        email_por_uid[user_id] = email
+        dados_por_uid[user_id].append(tuple(dados))
+    return [(email_por_uid[uid], dados_por_uid[uid]) for uid in ordem_uids]
 
 
 def verificar_contas_vencendo(app):
     with app.app_context():
         try:
             from utils.email_service import send_alert_contas
-            usuarios = _get_usuarios_com_email()
-            for uid, email in usuarios:
-                with get_db_cursor() as cursor:
-                    cursor.execute(
-                        "SELECT descricao, valor, vencimento FROM financial_schedule "
-                        "WHERE user_id = %s AND status = 'pendente' AND deleted_at IS NULL "
-                        "AND vencimento <= DATE_ADD(CURDATE(), INTERVAL 3 DAY) "
-                        "ORDER BY vencimento ASC",
-                        (uid,)
-                    )
-                    contas = cursor.fetchall()
-                if contas:
-                    send_alert_contas(email, contas)
+            with get_db_cursor() as cursor:
+                cursor.execute(
+                    "SELECT fs.user_id, u.email, fs.descricao, fs.valor, fs.vencimento "
+                    "FROM financial_schedule fs "
+                    "JOIN usuarios u ON u.id = fs.user_id "
+                    "WHERE fs.status = 'pendente' AND fs.deleted_at IS NULL "
+                    "AND fs.vencimento <= DATE_ADD(CURDATE(), INTERVAL 3 DAY) "
+                    "AND u.email IS NOT NULL AND u.email != '' "
+                    "ORDER BY fs.user_id, fs.vencimento ASC"
+                )
+                rows = cursor.fetchall()
+            for email, contas in _agrupar_por_usuario(rows):
+                send_alert_contas(email, contas)
         except Exception as e:
             logger.error(f"Alerta contas: {e}", exc_info=True)
 
@@ -35,19 +47,19 @@ def verificar_protocolos_vencendo(app):
     with app.app_context():
         try:
             from utils.email_service import send_alert_protocolo
-            usuarios = _get_usuarios_com_email()
-            for uid, email in usuarios:
-                with get_db_cursor() as cursor:
-                    cursor.execute(
-                        "SELECT nome, proxima_aplicacao FROM protocolos_sanitarios "
-                        "WHERE user_id = %s AND ativo = 1 "
-                        "AND proxima_aplicacao <= DATE_ADD(CURDATE(), INTERVAL 7 DAY) "
-                        "ORDER BY proxima_aplicacao ASC",
-                        (uid,)
-                    )
-                    protocolos = cursor.fetchall()
-                if protocolos:
-                    send_alert_protocolo(email, protocolos)
+            with get_db_cursor() as cursor:
+                cursor.execute(
+                    "SELECT ps.user_id, u.email, ps.nome, ps.proxima_aplicacao "
+                    "FROM protocolos_sanitarios ps "
+                    "JOIN usuarios u ON u.id = ps.user_id "
+                    "WHERE ps.ativo = 1 "
+                    "AND ps.proxima_aplicacao <= DATE_ADD(CURDATE(), INTERVAL 7 DAY) "
+                    "AND u.email IS NOT NULL AND u.email != '' "
+                    "ORDER BY ps.user_id, ps.proxima_aplicacao ASC"
+                )
+                rows = cursor.fetchall()
+            for email, protocolos in _agrupar_por_usuario(rows):
+                send_alert_protocolo(email, protocolos)
         except Exception as e:
             logger.error(f"Alerta protocolos: {e}", exc_info=True)
 
@@ -74,17 +86,18 @@ def verificar_estoque_critico(app):
     with app.app_context():
         try:
             from utils.email_service import send_alert_estoque
-            usuarios = _get_usuarios_com_email()
-            for uid, email in usuarios:
-                with get_db_cursor() as cursor:
-                    cursor.execute(
-                        "SELECT nome, saldo_atual, unidade, proxima_validade, tem_vencido "
-                        "FROM vw_saldo_estoque "
-                        "WHERE user_id = %s AND (abaixo_minimo = 1 OR tem_vencido = 1)",
-                        (uid,)
-                    )
-                    produtos = cursor.fetchall()
-                if produtos:
-                    send_alert_estoque(email, produtos)
+            with get_db_cursor() as cursor:
+                cursor.execute(
+                    "SELECT v.user_id, u.email, v.nome, v.saldo_atual, v.unidade, "
+                    "  v.proxima_validade, v.tem_vencido "
+                    "FROM vw_saldo_estoque v "
+                    "JOIN usuarios u ON u.id = v.user_id "
+                    "WHERE (v.abaixo_minimo = 1 OR v.tem_vencido = 1) "
+                    "AND u.email IS NOT NULL AND u.email != '' "
+                    "ORDER BY v.user_id"
+                )
+                rows = cursor.fetchall()
+            for email, produtos in _agrupar_por_usuario(rows):
+                send_alert_estoque(email, produtos)
         except Exception as e:
             logger.error(f"Alerta estoque: {e}", exc_info=True)


### PR DESCRIPTION
## Sumário
- `relatorio_pdf` calcula `gmd_medio` em Python a partir de `get_animais_com_gmd` (que já traz o gmd por animal) em vez de disparar uma segunda query com `get_gmd_medio_rebanho` (#19)
- Jobs agendados em `utils/alertas.py` (`verificar_contas_vencendo`, `verificar_protocolos_vencendo`, `verificar_estoque_critico`) trocam o loop 1-query-por-usuário por uma única query agrupada com JOIN em `usuarios`, agregada em memória por `user_id` (#14)

Closes #19
Closes #14

## Test plan
- [x] `pytest tests/` — 272 passed (1 teste novo cobrindo que a query agrupada não mistura contas de usuários diferentes)