### PR TITLE
Sessão 5: views/queries de GMD e pastos (#16, #12)

### DIFF
--- a/init_db.py
+++ b/init_db.py
@@ -481,40 +481,52 @@ def criar_schema(cursor):
     GROUP BY m.id, m.pasto_id, m.user_id, m.nome;
     """)
 
+    # GMD calculado inline (CTE filtrando pelos animais do módulo antes da window
+    # function), em vez de LEFT JOIN em v_gmd_analitico — essa view roda a window
+    # function sobre pesagens de todos os tenants antes de qualquer filtro, então
+    # o join materializava o GMD da plataforma inteira a cada chamada.
     cursor.execute("""
     CREATE OR REPLACE VIEW vw_gmd_por_modulo AS
+    WITH oa_rel AS (
+        SELECT o.modulo_id, m.nome AS modulo_nome, m.pasto_id, m.user_id, oa.animal_id
+        FROM ocupacoes o
+        JOIN ocupacao_animais oa ON oa.ocupacao_id = o.id
+        JOIN modulos m ON m.id = o.modulo_id
+    ),
+    po AS (
+        SELECT p.animal_id, p.data_pesagem, p.peso,
+            ROW_NUMBER() OVER (PARTITION BY p.animal_id ORDER BY p.data_pesagem ASC)  AS rn_asc,
+            ROW_NUMBER() OVER (PARTITION BY p.animal_id ORDER BY p.data_pesagem DESC) AS rn_desc
+        FROM pesagens p
+        JOIN oa_rel r ON r.animal_id = p.animal_id
+        WHERE p.deleted_at IS NULL
+    ),
+    pu AS (
+        SELECT animal_id,
+            MAX(CASE WHEN rn_asc  = 1 THEN data_pesagem END) AS data_ini,
+            MAX(CASE WHEN rn_asc  = 1 THEN peso END)         AS peso_ini,
+            MAX(CASE WHEN rn_desc = 1 THEN data_pesagem END) AS data_fim,
+            MAX(CASE WHEN rn_desc = 1 THEN peso END)         AS peso_fim
+        FROM po GROUP BY animal_id
+    ),
+    gmd_calc AS (
+        SELECT animal_id,
+            CASE WHEN DATEDIFF(data_fim, data_ini) > 0
+                THEN (peso_fim - peso_ini) / DATEDIFF(data_fim, data_ini)
+                ELSE NULL END AS gmd
+        FROM pu WHERE data_ini <> data_fim
+    )
     SELECT
-        o.modulo_id,
-        m.nome AS modulo_nome,
-        m.pasto_id,
-        m.user_id,
-        COUNT(DISTINCT oa.animal_id) AS qtd_animais,
+        r.modulo_id, r.modulo_nome, r.pasto_id, r.user_id,
+        COUNT(DISTINCT r.animal_id) AS qtd_animais,
         ROUND(AVG(g.gmd), 3) AS gmd_medio
-    FROM ocupacoes o
-    JOIN ocupacao_animais oa ON oa.ocupacao_id = o.id
-    JOIN modulos m ON m.id = o.modulo_id
-    LEFT JOIN v_gmd_analitico g ON g.animal_id = oa.animal_id
-    GROUP BY o.modulo_id, m.nome, m.pasto_id, m.user_id;
+    FROM oa_rel r
+    LEFT JOIN gmd_calc g ON g.animal_id = r.animal_id
+    GROUP BY r.modulo_id, r.modulo_nome, r.pasto_id, r.user_id;
     """)
 
-    # 2.1c Views de Hereditariedade
-    print(" Criando Views de Hereditariedade...")
-
-    cursor.execute("""
-    CREATE OR REPLACE VIEW vw_gmd_por_touro AS
-    SELECT
-        pai.id AS touro_id,
-        pai.brinco AS touro_brinco,
-        pai.raca AS touro_raca,
-        pai.user_id,
-        COUNT(DISTINCT filho.id) AS qtd_filhos,
-        ROUND(AVG(g.gmd), 3) AS gmd_medio_filhos
-    FROM animais pai
-    JOIN animais filho ON filho.pai_id = pai.id AND filho.deleted_at IS NULL
-    LEFT JOIN v_gmd_analitico g ON g.animal_id = filho.id
-    WHERE pai.deleted_at IS NULL
-    GROUP BY pai.id, pai.brinco, pai.raca, pai.user_id;
-    """)
+    # vw_gmd_por_touro removida — sem call site em routes/repositories, view morta.
+    cursor.execute("DROP VIEW IF EXISTS vw_gmd_por_touro;")
 
     cursor.execute("""
     CREATE OR REPLACE VIEW vw_historico_vaca AS

--- a/repositories/pasto_repository.py
+++ b/repositories/pasto_repository.py
@@ -4,16 +4,24 @@ from db_config import get_db_cursor
 # ---- PASTOS ----
 
 def get_pastos(user_id):
-    """Lista pastos do usuário com contagem de módulos e alertas de lotação."""
+    """Lista pastos do usuário com contagem de módulos e alertas de lotação.
+
+    Um único LEFT JOIN agregado em vez de 3 subqueries correlacionadas por
+    linha — vw_ocupacao_atual já é uma view com GROUP BY por módulo, então
+    reprocessá-la 2x por pasto era redundante.
+    """
     with get_db_cursor() as cursor:
         cursor.execute(
             "SELECT p.id, p.nome, p.area_hectares, p.forrageira, p.capacidade_ua, "
-            "    (SELECT COUNT(*) FROM modulos m WHERE m.pasto_id = p.id) AS qtd_modulos, "
-            "    (SELECT COUNT(*) FROM vw_ocupacao_atual va "
-            "     WHERE va.pasto_id = p.id AND va.pct_lotacao > 100) AS superlotados, "
-            "    (SELECT COUNT(*) FROM vw_ocupacao_atual va "
-            "     WHERE va.pasto_id = p.id AND va.pct_lotacao BETWEEN 80 AND 100) AS em_alerta "
-            "FROM pastos p WHERE p.user_id = %s ORDER BY p.nome",
+            "    COUNT(DISTINCT m.id) AS qtd_modulos, "
+            "    COUNT(DISTINCT CASE WHEN va.pct_lotacao > 100 THEN va.modulo_id END) AS superlotados, "
+            "    COUNT(DISTINCT CASE WHEN va.pct_lotacao BETWEEN 80 AND 100 THEN va.modulo_id END) AS em_alerta "
+            "FROM pastos p "
+            "LEFT JOIN modulos m ON m.pasto_id = p.id "
+            "LEFT JOIN vw_ocupacao_atual va ON va.modulo_id = m.id "
+            "WHERE p.user_id = %s "
+            "GROUP BY p.id, p.nome, p.area_hectares, p.forrageira, p.capacidade_ua "
+            "ORDER BY p.nome",
             (user_id,)
         )
         return cursor.fetchall()

--- a/tests/test_pastos.py
+++ b/tests/test_pastos.py
@@ -218,6 +218,21 @@ def test_modulo_encerrado_aparece_em_dias_descanso(um):
     assert any(row[0] == mid for row in descanso)
 
 
+def test_get_pastos_agrega_modulos_e_alertas_lotacao(um):
+    aid = _make_animal(um)
+    pid = pasto_repository.insert_pasto(um, "P Agregado", None, None, None)
+    m_livre = pasto_repository.insert_modulo(pid, um, "M Livre", None, 5.0)
+    m_super = pasto_repository.insert_modulo(pid, um, "M Super", None, 0.5)
+    pasto_repository.iniciar_ocupacao(m_super, um, "2024-03-01", [aid])
+
+    pastos = pasto_repository.get_pastos(um)
+    row = next(p for p in pastos if p[0] == pid)
+    # id, nome, area_hectares, forrageira, capacidade_ua, qtd_modulos, superlotados, em_alerta
+    assert row[5] == 2       # qtd_modulos: livre + super, sem duplicar por ocupação
+    assert row[6] == 1       # superlotados: 1 animal / capacidade 0.5 UA = 200%
+    assert row[7] == 0       # em_alerta: nenhum módulo entre 80% e 100%
+
+
 def test_get_gmd_por_modulo_calcula_gmd_do_animal_ocupante(um):
     conn = dbc.get_db_connection()
     cur = conn.cursor()

--- a/tests/test_pastos.py
+++ b/tests/test_pastos.py
@@ -218,6 +218,30 @@ def test_modulo_encerrado_aparece_em_dias_descanso(um):
     assert any(row[0] == mid for row in descanso)
 
 
+def test_get_gmd_por_modulo_calcula_gmd_do_animal_ocupante(um):
+    conn = dbc.get_db_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO animais (brinco, sexo, data_compra, preco_compra, user_id) "
+        "VALUES (%s, 'M', '2024-01-01', 1000, %s)",
+        (f"PGMD{_n()}", um),
+    )
+    aid = cur.lastrowid
+    cur.execute("INSERT INTO pesagens (animal_id, data_pesagem, peso) VALUES (%s, '2024-01-01', 300)", (aid,))
+    cur.execute("INSERT INTO pesagens (animal_id, data_pesagem, peso) VALUES (%s, '2024-01-11', 310)", (aid,))
+    conn.commit(); cur.close(); conn.close()
+
+    pid = pasto_repository.insert_pasto(um, "P GMD", None, None, 5.0)
+    mid = pasto_repository.insert_modulo(pid, um, "M GMD", None, 5.0)
+    pasto_repository.iniciar_ocupacao(mid, um, "2024-01-01", [aid])
+
+    ranking = pasto_repository.get_gmd_por_modulo(um)
+    row = next(r for r in ranking if r[0] == mid)
+    # modulo_id, modulo_nome, pasto_id, qtd_animais, gmd_medio
+    assert row[3] == 1
+    assert float(row[4]) == pytest.approx(1.0)
+
+
 # ── rotas HTTP ────────────────────────────────────────────────────────────────
 
 def test_get_pastos_redireciona_sem_login(client):


### PR DESCRIPTION
## Sumário
- `vw_gmd_por_modulo` deixa de depender de `v_gmd_analitico` (window function sobre pesagens de todos os tenants) e passa a usar CTE inline filtrada pelos animais ocupantes do módulo, mesmo padrão de `get_gmd_medio_rebanho`. Remove `vw_gmd_por_touro` (view morta, sem call site — `get_ranking_touros` já calcula o mesmo ranking inline) (#16)
- `get_pastos()` troca 3 subqueries correlacionadas por pasto (reprocessando `vw_ocupacao_atual` até 3x) por um único `LEFT JOIN` agregado com `COUNT(DISTINCT ...)` (#12)

Closes #16
Closes #12

## Test plan
- [x] `pytest tests/` — 273 passed (2 testes novos: GMD por módulo com animal ocupante real, e agregação de módulos/alertas de lotação em `get_pastos`)
- [ ] Rodar `EXPLAIN` antes/depois em `vw_gmd_por_modulo` e `get_pastos()` com uma base de dados maior para confirmar o ganho