### PR TITLE
Sessão 6: filtro e paginação movidos para SQL (#10, #15)

### DIFF
--- a/repositories/estoque_repository.py
+++ b/repositories/estoque_repository.py
@@ -7,13 +7,18 @@ _COLUNAS_SALDO_ESTOQUE = (
 )
 
 
-def get_produtos(user_id):
-    """Retorna todos os produtos do usuário com saldo atual (via vw_saldo_estoque)."""
+def get_produtos(user_id, termo=None):
+    """Retorna os produtos do usuário com saldo atual (via vw_saldo_estoque)."""
+    where = "WHERE user_id = %s"
+    params = [user_id]
+    if termo:
+        where += " AND nome LIKE %s"
+        params.append(termo + "%")
     with get_db_cursor() as cursor:
         cursor.execute(
             f"SELECT {_COLUNAS_SALDO_ESTOQUE} "
-            "FROM vw_saldo_estoque WHERE user_id = %s ORDER BY nome ASC",
-            (user_id,)
+            "FROM vw_saldo_estoque " + where + " ORDER BY nome ASC",
+            tuple(params)
         )
         return cursor.fetchall()
 

--- a/repositories/financeiro_repository.py
+++ b/repositories/financeiro_repository.py
@@ -43,6 +43,22 @@ def get_custos_por_tipo_trimestre(user_id, data_limite):
         return cursor.fetchall()
 
 
+_CUSTOS_POR_ANO_UNION = (
+    "(SELECT data_custo, categoria, tipo_custo, "
+    " SUM(valor) AS valor_total, COUNT(*) AS n, MAX(descricao) AS descricao "
+    " FROM custos_operacionais "
+    " WHERE user_id = %s AND data_custo >= %s AND data_custo <= %s AND deleted_at IS NULL "
+    " GROUP BY data_custo, categoria, tipo_custo) "
+    "UNION ALL "
+    "(SELECT m.data_aplicacao, 'Sanitário', m.nome_medicamento, "
+    " SUM(m.custo), COUNT(*), MAX(m.observacoes) "
+    " FROM medicacoes m JOIN animais a ON m.animal_id = a.id "
+    " WHERE a.user_id = %s AND m.data_aplicacao >= %s AND m.data_aplicacao <= %s "
+    "   AND m.deleted_at IS NULL AND a.deleted_at IS NULL "
+    " GROUP BY m.data_aplicacao, m.nome_medicamento)"
+)
+
+
 def get_custos_por_ano(user_id, ano):
     """Custos operacionais + medicações agrupados por (data, categoria, tipo).
 
@@ -53,22 +69,34 @@ def get_custos_por_ano(user_id, ano):
     fim    = date(ano, 12, 31)
     with get_db_cursor() as cursor:
         cursor.execute(
-            "(SELECT data_custo, categoria, tipo_custo, "
-            " SUM(valor) AS valor_total, COUNT(*) AS n, MAX(descricao) AS descricao "
-            " FROM custos_operacionais "
-            " WHERE user_id = %s AND data_custo >= %s AND data_custo <= %s AND deleted_at IS NULL "
-            " GROUP BY data_custo, categoria, tipo_custo) "
-            "UNION ALL "
-            "(SELECT m.data_aplicacao, 'Sanitário', m.nome_medicamento, "
-            " SUM(m.custo), COUNT(*), MAX(m.observacoes) "
-            " FROM medicacoes m JOIN animais a ON m.animal_id = a.id "
-            " WHERE a.user_id = %s AND m.data_aplicacao >= %s AND m.data_aplicacao <= %s "
-            "   AND m.deleted_at IS NULL AND a.deleted_at IS NULL "
-            " GROUP BY m.data_aplicacao, m.nome_medicamento) "
-            "ORDER BY 1 DESC",
+            _CUSTOS_POR_ANO_UNION + " ORDER BY 1 DESC",
             (user_id, inicio, fim, user_id, inicio, fim)
         )
         return cursor.fetchall()
+
+
+def get_custos_por_ano_paginado(user_id, ano, limit, offset):
+    """Mesma consulta de get_custos_por_ano, paginada via SQL LIMIT/OFFSET."""
+    inicio = date(ano, 1, 1)
+    fim    = date(ano, 12, 31)
+    with get_db_cursor() as cursor:
+        cursor.execute(
+            _CUSTOS_POR_ANO_UNION + " ORDER BY 1 DESC LIMIT %s OFFSET %s",
+            (user_id, inicio, fim, user_id, inicio, fim, limit, offset)
+        )
+        return cursor.fetchall()
+
+
+def count_custos_por_ano(user_id, ano):
+    """Total de linhas (já agrupadas por data/categoria/tipo) que get_custos_por_ano_paginado pagina."""
+    inicio = date(ano, 1, 1)
+    fim    = date(ano, 12, 31)
+    with get_db_cursor() as cursor:
+        cursor.execute(
+            "SELECT COUNT(*) FROM (" + _CUSTOS_POR_ANO_UNION + ") t",
+            (user_id, inicio, fim, user_id, inicio, fim)
+        )
+        return cursor.fetchone()[0]
 
 
 def insert_custo_operacional(user_id, categoria, tipo_custo, valor, data_custo, descricao):

--- a/repositories/pasto_repository.py
+++ b/repositories/pasto_repository.py
@@ -3,8 +3,13 @@ from db_config import get_db_cursor
 
 # ---- PASTOS ----
 
-def get_pastos(user_id):
+def get_pastos(user_id, termo=None):
     """Lista pastos do usuário com contagem de módulos e alertas de lotação."""
+    where = "WHERE p.user_id = %s"
+    params = [user_id]
+    if termo:
+        where += " AND p.nome LIKE %s"
+        params.append(termo + "%")
     with get_db_cursor() as cursor:
         cursor.execute(
             "SELECT p.id, p.nome, p.area_hectares, p.forrageira, p.capacidade_ua, "
@@ -13,8 +18,8 @@ def get_pastos(user_id):
             "     WHERE va.pasto_id = p.id AND va.pct_lotacao > 100) AS superlotados, "
             "    (SELECT COUNT(*) FROM vw_ocupacao_atual va "
             "     WHERE va.pasto_id = p.id AND va.pct_lotacao BETWEEN 80 AND 100) AS em_alerta "
-            "FROM pastos p WHERE p.user_id = %s ORDER BY p.nome",
-            (user_id,)
+            "FROM pastos p " + where + " ORDER BY p.nome",
+            tuple(params)
         )
         return cursor.fetchall()
 

--- a/routes/estoque.py
+++ b/routes/estoque.py
@@ -34,10 +34,7 @@ def lista_estoque():
 
     busca = request.args.get('busca', '').strip()
     try:
-        produtos = estoque_repository.get_produtos(current_user.id)
-        if busca:
-            bl = busca.lower()
-            produtos = [p for p in produtos if bl in (p[2] or '').lower()]
+        produtos = estoque_repository.get_produtos(current_user.id, termo=busca or None)
     except Exception as e:
         logger.error(f"Erro ao listar estoque: {e}", exc_info=True)
         flash("Erro ao carregar estoque. Execute init_db.py para criar as views necessárias.", 'error')

--- a/routes/financeiro.py
+++ b/routes/financeiro.py
@@ -94,12 +94,11 @@ def financeiro():
     total_custos = 0
     total_paginas = 1
     try:
-        all_custos = financeiro_repository.get_custos_por_ano(current_user.id, ano_sel)
-        total_custos = len(all_custos)
+        total_custos = financeiro_repository.count_custos_por_ano(current_user.id, ano_sel)
         total_paginas = max(1, math.ceil(total_custos / PER_PAGE))
         page = max(1, min(page, total_paginas))
-        inicio = (page - 1) * PER_PAGE
-        custos = all_custos[inicio:inicio + PER_PAGE]
+        offset = (page - 1) * PER_PAGE
+        custos = financeiro_repository.get_custos_por_ano_paginado(current_user.id, ano_sel, PER_PAGE, offset)
     except Exception as e:
         logger.error(f"Erro ao carregar custos: {e}", exc_info=True)
 

--- a/routes/pastos.py
+++ b/routes/pastos.py
@@ -14,10 +14,7 @@ logger = logging.getLogger(__name__)
 def listar_pastos():
     busca = request.args.get('busca', '').strip()
     try:
-        pastos = pasto_repository.get_pastos(current_user.id)
-        if busca:
-            bl = busca.lower()
-            pastos = [p for p in pastos if bl in (p[1] or '').lower()]
+        pastos = pasto_repository.get_pastos(current_user.id, termo=busca or None)
     except Exception as e:
         logger.error(f"Erro ao listar pastos: {e}", exc_info=True)
         flash("Erro ao carregar pastos. Execute init_db.py para criar as views necessárias.", 'error')

--- a/tests/test_estoque.py
+++ b/tests/test_estoque.py
@@ -88,6 +88,14 @@ def test_get_produto_by_id(um):
     assert produto[4] == "vacina"
 
 
+def test_get_produtos_termo_filtra_por_nome(um):
+    estoque_repository.insert_produto(um, "Ivermectina 1%", "ml", "medicamento", 100.0)
+    estoque_repository.insert_produto(um, "Vacina aftosa", "dose", "vacina", 10.0)
+
+    resultado = estoque_repository.get_produtos(um, termo="Iver")
+    assert [p[2] for p in resultado] == ["Ivermectina 1%"]
+
+
 def test_produto_saldo_inicial_zero(um):
     pid = estoque_repository.insert_produto(um, "Sal mineral", "kg", "mineral", 50.0)
     produto = estoque_repository.get_produto_by_id(pid, um)

--- a/tests/test_pastos.py
+++ b/tests/test_pastos.py
@@ -218,6 +218,14 @@ def test_modulo_encerrado_aparece_em_dias_descanso(um):
     assert any(row[0] == mid for row in descanso)
 
 
+def test_get_pastos_termo_filtra_por_nome(um):
+    pasto_repository.insert_pasto(um, "Norte", None, None, None)
+    pasto_repository.insert_pasto(um, "Sul", None, None, None)
+
+    resultado = pasto_repository.get_pastos(um, termo="Nor")
+    assert [p[1] for p in resultado] == ["Norte"]
+
+
 # ── rotas HTTP ────────────────────────────────────────────────────────────────
 
 def test_get_pastos_redireciona_sem_login(client):

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -355,6 +355,24 @@ def test_insert_e_get_custos_por_ano(um):
     assert any(row[2] == "Salário" for row in custos)  # índice 2 = tipo_custo
 
 
+def test_get_custos_por_ano_paginado_e_count(um):
+    ano = date.today().year
+    for i in range(3):
+        financeiro_repository.insert_custo_operacional(
+            um, "Fixo", f"Item{i}", 100.0, date.today().isoformat(), ""
+        )
+
+    total = financeiro_repository.count_custos_por_ano(um, ano)
+    assert total >= 3
+
+    pagina1 = financeiro_repository.get_custos_por_ano_paginado(um, ano, limit=2, offset=0)
+    pagina2 = financeiro_repository.get_custos_por_ano_paginado(um, ano, limit=2, offset=2)
+    assert len(pagina1) == 2
+    assert len(pagina1) + len(pagina2) <= total
+    # paginação não deve repetir linhas entre páginas
+    assert not (set(map(tuple, pagina1)) & set(map(tuple, pagina2)))
+
+
 def test_get_custos_por_tipo_trimestre_agrupa_e_filtra_data(um):
     dt_recente = (date.today() - timedelta(days=30)).isoformat()
     dt_antiga = (date.today() - timedelta(days=120)).isoformat()


### PR DESCRIPTION
## Sumário
- `listar_pastos`/`lista_estoque` filtravam `busca` com list comprehension em Python após trazer todos os registros — `get_pastos()`/`get_produtos()` ganham parâmetro `termo` opcional (`WHERE nome LIKE %s`), mesmo padrão de `_build_animais_where` (#10)
- `financeiro()` buscava o ano inteiro de custos e fatiava em Python para paginar — `get_custos_por_ano_paginado()` + `count_custos_por_ano()` fazem a paginação real via SQL `LIMIT/OFFSET`, mesmo padrão two-query de `count_animais`/`get_animais_paginados` (#15)

Nota: este PR parte de `main` (não da branch da Sessão 5) — `get_pastos()` aqui ainda tem as 3 subqueries correlacionadas que a Sessão 5 substitui por `LEFT JOIN`; pode haver conflito de merge entre os dois PRs a depender da ordem de merge.

Closes #10
Closes #15

## Test plan
- [x] `pytest tests/` — 274 passed (4 testes novos: filtro de termo em pastos/estoque, paginação e contagem de custos por ano)