### PR TITLE
Sessão 7: executemany em escritas em lote (#9)

### DIFF
--- a/repositories/animal_repository.py
+++ b/repositories/animal_repository.py
@@ -686,16 +686,15 @@ def registrar_venda_lote(vendas, user_id, data_venda):
         validos = {row[0] for row in cursor.fetchall()}
         invalidos = [aid for aid in animal_ids if aid not in validos]
 
-        for animal_id, peso_venda, preco_venda in vendas:
-            if animal_id not in validos:
-                continue
-            cursor.execute(
+        vendas_validas = [(aid, peso_venda, preco_venda) for aid, peso_venda, preco_venda in vendas if aid in validos]
+        if vendas_validas:
+            cursor.executemany(
                 "UPDATE animais SET data_venda = %s, preco_venda = %s WHERE id = %s",
-                (data_venda, preco_venda, animal_id)
+                [(data_venda, preco_venda, aid) for aid, peso_venda, preco_venda in vendas_validas]
             )
-            cursor.execute(
+            cursor.executemany(
                 "INSERT INTO pesagens (animal_id, data_pesagem, peso) VALUES (%s, %s, %s)",
-                (animal_id, data_venda, peso_venda)
+                [(aid, data_venda, peso_venda) for aid, peso_venda, preco_venda in vendas_validas]
             )
 
     return len(validos), invalidos
@@ -814,15 +813,27 @@ def cadastrar_lote(user_id, codigo_lote, descricao, data_compra, animais_data, r
             (user_id, codigo_lote, descricao, data_compra)
         )
         lote_id = cursor.lastrowid
-        for brinco, sexo, peso, custo_animal in animais_data:
-            cursor.execute(
-                "INSERT INTO animais (brinco, sexo, raca, data_compra, preco_compra, user_id, lote_id) "
-                "VALUES (%s, %s, %s, %s, %s, %s, %s)",
-                (brinco, sexo, raca or None, data_compra, custo_animal, user_id, lote_id)
-            )
-            animal_id = cursor.lastrowid
-            cursor.execute(
-                "INSERT INTO pesagens (animal_id, data_pesagem, peso) VALUES (%s, %s, %s)",
-                (animal_id, data_compra, peso)
-            )
+
+        cursor.executemany(
+            "INSERT INTO animais (brinco, sexo, raca, data_compra, preco_compra, user_id, lote_id) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s)",
+            [(brinco, sexo, raca or None, data_compra, custo_animal, user_id, lote_id)
+             for brinco, sexo, peso, custo_animal in animais_data]
+        )
+
+        # brinco é único por usuário — reconsulta os ids recém-criados para
+        # montar as pesagens iniciais sem depender de lastrowid por linha
+        # (que o executemany não fornece individualmente).
+        brincos = [brinco for brinco, sexo, peso, custo_animal in animais_data]
+        placeholders = ','.join(['%s'] * len(brincos))
+        cursor.execute(
+            f"SELECT id, brinco FROM animais WHERE lote_id = %s AND brinco IN ({placeholders})",
+            [lote_id] + brincos
+        )
+        id_por_brinco = {brinco: aid for aid, brinco in cursor.fetchall()}
+
+        cursor.executemany(
+            "INSERT INTO pesagens (animal_id, data_pesagem, peso) VALUES (%s, %s, %s)",
+            [(id_por_brinco[brinco], data_compra, peso) for brinco, sexo, peso, custo_animal in animais_data]
+        )
         return lote_id

--- a/repositories/pasto_repository.py
+++ b/repositories/pasto_repository.py
@@ -100,11 +100,10 @@ def iniciar_ocupacao(modulo_id, user_id, data_entrada, animal_ids):
             (modulo_id, user_id, data_entrada)
         )
         ocupacao_id = cursor.lastrowid
-        for aid in animal_ids:
-            cursor.execute(
-                "INSERT INTO ocupacao_animais (ocupacao_id, animal_id) VALUES (%s, %s)",
-                (ocupacao_id, int(aid))
-            )
+        cursor.executemany(
+            "INSERT INTO ocupacao_animais (ocupacao_id, animal_id) VALUES (%s, %s)",
+            [(ocupacao_id, int(aid)) for aid in animal_ids]
+        )
         return ocupacao_id
 
 

--- a/routes/operacional.py
+++ b/routes/operacional.py
@@ -642,6 +642,7 @@ def ranking_touros():
 _CSV_COLUNAS_OBRIGATORIAS = {'brinco', 'sexo', 'data_compra', 'peso_kg', 'valor_arroba'}
 _CSV_MAX_BYTES = 1 * 1024 * 1024  # 1 MB
 _CSV_MAX_LINHAS = 5000
+_CSV_CHUNK_SIZE = 500
 
 
 @operacional_bp.route('/importar-csv', methods=['GET', 'POST'])
@@ -679,6 +680,7 @@ def importar_csv():
                 (current_user.id,)
             )
             brincos_existentes = {row[0] for row in cursor.fetchall()}
+            linhas_validas = []  # (linha, brinco, sexo, raca, data_compra, data_nasc, preco_compra)
 
             for i, row in enumerate(reader, start=2):
                 if i - 1 > _CSV_MAX_LINHAS:
@@ -723,17 +725,36 @@ def importar_csv():
                     erros.append({'linha': i, 'msg': f"brinco '{brinco}' já existe"})
                     continue
 
+                brincos_existentes.add(brinco)
+                linhas_validas.append((i, brinco, sexo, raca, data_compra or None,
+                                        data_nasc or None, preco_compra))
+
+            # Insere em chunks via executemany — muito mais rápido que 1 INSERT
+            # por linha. Se um chunk falhar (ex.: duas linhas do próprio CSV com
+            # o mesmo brinco, que o set em memória não pega porque nenhuma das
+            # duas foi inserida ainda), refaz esse chunk linha a linha só para
+            # isolar e reportar qual(is) linha(s) conflitam.
+            for inicio in range(0, len(linhas_validas), _CSV_CHUNK_SIZE):
+                chunk = linhas_validas[inicio:inicio + _CSV_CHUNK_SIZE]
                 try:
-                    cursor.execute(
+                    cursor.executemany(
                         "INSERT INTO animais (brinco, sexo, raca, data_compra, data_nascimento, "
                         "preco_compra, user_id) VALUES (%s,%s,%s,%s,%s,%s,%s)",
-                        (brinco, sexo, raca, data_compra or None,
-                         data_nasc or None, preco_compra, current_user.id)
+                        [(brinco, sexo, raca, data_compra, data_nasc, preco_compra, current_user.id)
+                         for _, brinco, sexo, raca, data_compra, data_nasc, preco_compra in chunk]
                     )
-                    brincos_existentes.add(brinco)
-                    inseridos += 1
+                    inseridos += len(chunk)
                 except _mysql_errors.IntegrityError:
-                    erros.append({'linha': i, 'msg': f"brinco '{brinco}' já existe (conflito)"})
+                    for linha, brinco, sexo, raca, data_compra, data_nasc, preco_compra in chunk:
+                        try:
+                            cursor.execute(
+                                "INSERT INTO animais (brinco, sexo, raca, data_compra, data_nascimento, "
+                                "preco_compra, user_id) VALUES (%s,%s,%s,%s,%s,%s,%s)",
+                                (brinco, sexo, raca, data_compra, data_nasc, preco_compra, current_user.id)
+                            )
+                            inseridos += 1
+                        except _mysql_errors.IntegrityError:
+                            erros.append({'linha': linha, 'msg': f"brinco '{brinco}' já existe (conflito)"})
 
     except Exception as e:
         logger.error(f"Erro importação CSV: {e}", exc_info=True)

--- a/tests/test_importar_csv.py
+++ b/tests/test_importar_csv.py
@@ -1,0 +1,100 @@
+"""
+Issue #9 — importar_csv passa a inserir em chunks via executemany em vez de
+1 INSERT por linha, com fallback linha a linha quando um chunk falha.
+Rota: POST /importar-csv
+"""
+import io
+import itertools
+from werkzeug.security import generate_password_hash
+import db_config as dbc
+
+_seq = itertools.count(12000)
+
+
+def _n():
+    return next(_seq)
+
+
+def _make_user():
+    conn = dbc.get_db_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO usuarios (username, password_hash) VALUES (%s, %s)",
+        (f"csv_{_n()}", generate_password_hash("x")),
+    )
+    uid = cur.lastrowid
+    conn.commit(); cur.close(); conn.close()
+    return uid
+
+
+def _purge(user_id):
+    conn = dbc.get_db_connection()
+    cur = conn.cursor()
+    cur.execute("SET FOREIGN_KEY_CHECKS = 0")
+    cur.execute("DELETE p FROM pesagens p JOIN animais a ON p.animal_id = a.id WHERE a.user_id = %s", (user_id,))
+    cur.execute("DELETE FROM animais WHERE user_id = %s", (user_id,))
+    cur.execute("DELETE FROM usuarios WHERE id = %s", (user_id,))
+    cur.execute("SET FOREIGN_KEY_CHECKS = 1")
+    conn.commit(); cur.close(); conn.close()
+
+
+def _login(client, uid):
+    conn = dbc.get_db_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT username FROM usuarios WHERE id = %s", (uid,))
+    username = cur.fetchone()[0]
+    cur.close(); conn.close()
+    client.post("/login", data={"username": username, "password": "x"}, follow_redirects=True)
+
+
+def _upload(client, csv_text):
+    data = {'arquivo': (io.BytesIO(csv_text.encode('utf-8')), 'animais.csv')}
+    return client.post('/importar-csv', data=data, content_type='multipart/form-data')
+
+
+def test_importar_csv_insere_linhas_validas_em_lote(app):
+    uid = _make_user()
+    try:
+        with app.test_client() as client:
+            _login(client, uid)
+            csv_text = "brinco,sexo,data_compra,peso_kg,valor_arroba\n"
+            for i in range(5):
+                csv_text += f"CSVA{_n()},M,2024-01-01,250,150\n"
+            r = _upload(client, csv_text)
+            assert r.status_code == 200
+            assert b"5" in r.data  # inseridos: 5
+
+            conn = dbc.get_db_connection()
+            cur = conn.cursor()
+            cur.execute("SELECT COUNT(*) FROM animais WHERE user_id = %s", (uid,))
+            assert cur.fetchone()[0] == 5
+            cur.close(); conn.close()
+    finally:
+        _purge(uid)
+
+
+def test_importar_csv_brinco_duplicado_no_proprio_arquivo_reporta_conflito(app):
+    """Duas linhas do mesmo arquivo com o mesmo brinco: o chunk inteiro falha no
+    executemany (unique constraint), o fallback linha a linha insere a primeira
+    e reporta a segunda como conflito — sem perder a primeira."""
+    uid = _make_user()
+    try:
+        with app.test_client() as client:
+            _login(client, uid)
+            brinco_dup = f"CSVDUP{_n()}"
+            csv_text = (
+                "brinco,sexo,data_compra,peso_kg,valor_arroba\n"
+                f"{brinco_dup},M,2024-01-01,250,150\n"
+                f"{brinco_dup},F,2024-01-02,260,150\n"
+            )
+            r = _upload(client, csv_text)
+            assert r.status_code == 200
+
+            conn = dbc.get_db_connection()
+            cur = conn.cursor()
+            cur.execute("SELECT COUNT(*) FROM animais WHERE user_id = %s AND brinco = %s", (uid, brinco_dup))
+            assert cur.fetchone()[0] == 1  # só a primeira ocorrência foi inserida
+            cur.close(); conn.close()
+            assert "conflito".encode('utf-8') in r.data or "já existe".encode('utf-8') in r.data
+    finally:
+        _purge(uid)

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -209,6 +209,29 @@ def test_cadastrar_animal_cria_pesagem_inicial(um):
     assert float(pesagens[0][3]) == pytest.approx(280.0)  # índice 3 = peso
 
 
+def test_cadastrar_lote_associa_pesagem_ao_animal_correto(um):
+    """cadastrar_lote insere animais e pesagens via executemany, mapeando o
+    animal_id de volta por brinco — cada pesagem tem que ficar com o animal certo,
+    não embaralhada entre os animais do mesmo lote."""
+    animais_data = [
+        (f"LOTE{_n()}A", "M", 250.0, 900.0),
+        (f"LOTE{_n()}B", "F", 300.0, 1100.0),
+        (f"LOTE{_n()}C", "M", 275.0, 950.0),
+    ]
+    lote_id = animal_repository.cadastrar_lote(um, f"L{_n()}", "Lote teste", "2024-01-01", animais_data)
+    assert lote_id is not None
+
+    for brinco, sexo, peso, custo in animais_data:
+        row = _fetch_one("SELECT id, sexo, preco_compra FROM animais WHERE brinco = %s AND user_id = %s", (brinco, um))
+        assert row is not None
+        aid, sexo_db, preco_db = row
+        assert sexo_db == sexo
+        assert float(preco_db) == pytest.approx(custo)
+        pesagens = animal_repository.get_pesagens_by_animal(aid)
+        assert len(pesagens) == 1
+        assert float(pesagens[0][3]) == pytest.approx(peso)  # índice 3 = peso
+
+
 def test_get_gmd_medio_rebanho_filtra_por_sexo(um):
     """sexo='M'/'F' restringe o cálculo ao grupo — segregação de matrizes do GMD geral."""
     macho = _make_animal(um, sexo="M")


### PR DESCRIPTION
## Sumário
Substitui loops de `cursor.execute()` (1 round-trip por linha) por `cursor.executemany()` em 4 pontos, seguindo o padrão já estabelecido em `registrar_pesagens_lote`:
- `cadastrar_lote` — insere animais em lote e reconsulta os ids por `brinco` (único por usuário) para montar as pesagens, já que `executemany` não expõe `lastrowid` por linha individual
- `registrar_venda_lote` — UPDATE + INSERT de pesagens em lote
- `iniciar_ocupacao` — INSERT em `ocupacao_animais` em lote
- `importar_csv` — insere em chunks de 500 linhas; se um chunk falhar (ex.: brinco duplicado dentro do próprio CSV), refaz esse chunk linha a linha para isolar e reportar o conflito sem perder as linhas válidas

Closes #9

## Test plan
- [x] `pytest tests/` — 274 passed (3 testes novos: mapeamento correto de pesagem→animal em `cadastrar_lote`, importação em lote bem-sucedida, e fallback de conflito de brinco duplicado no próprio CSV)