### PR TITLE
Sessão 8: atomicidade parto + bezerro (#18)

### DIFF
--- a/repositories/animal_repository.py
+++ b/repositories/animal_repository.py
@@ -619,6 +619,32 @@ def get_pesos_atuais_rebanho(user_id):
 
 # ---- ESCRITAS ATÔMICAS ----
 
+def _inserir_animal(cursor, brinco, sexo, data_compra, preco_compra, peso_entrada, user_id,
+                    data_nascimento=None, mae_id=None, pai_id=None, raca=None):
+    """Insere animal e pesagem inicial (quando disponível) usando um cursor já aberto.
+
+    Extraído de cadastrar_animal para ser reaproveitado por transações que
+    precisam inserir o animal junto com outra escrita (ex.: bezerro do parto
+    em reproducao_repository.registrar_parto_com_bezerro), sem abrir uma
+    segunda transação/commit separado.
+    """
+    cursor.execute(
+        "INSERT INTO animais "
+        "(brinco, sexo, raca, data_compra, data_nascimento, preco_compra, user_id, mae_id, pai_id) "
+        "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)",
+        (brinco, sexo, raca or None, data_compra or None, data_nascimento or None,
+         preco_compra or None, user_id, mae_id or None, pai_id or None)
+    )
+    animal_id = cursor.lastrowid
+    data_ref = data_compra or data_nascimento
+    if peso_entrada and data_ref:
+        cursor.execute(
+            "INSERT INTO pesagens (animal_id, data_pesagem, peso) VALUES (%s, %s, %s)",
+            (animal_id, data_ref, peso_entrada)
+        )
+    return animal_id
+
+
 def cadastrar_animal(brinco, sexo, data_compra, preco_compra, peso_entrada, user_id,
                      data_nascimento=None, mae_id=None, pai_id=None, raca=None):
     """Insere animal e pesagem inicial (quando disponível) na mesma transação. Retorna animal_id.
@@ -627,21 +653,8 @@ def cadastrar_animal(brinco, sexo, data_compra, preco_compra, peso_entrada, user
     Pesagem inicial só é inserida se peso_entrada for fornecido (> 0).
     """
     with get_db_cursor() as cursor:
-        cursor.execute(
-            "INSERT INTO animais "
-            "(brinco, sexo, raca, data_compra, data_nascimento, preco_compra, user_id, mae_id, pai_id) "
-            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)",
-            (brinco, sexo, raca or None, data_compra or None, data_nascimento or None,
-             preco_compra or None, user_id, mae_id or None, pai_id or None)
-        )
-        animal_id = cursor.lastrowid
-        data_ref = data_compra or data_nascimento
-        if peso_entrada and data_ref:
-            cursor.execute(
-                "INSERT INTO pesagens (animal_id, data_pesagem, peso) VALUES (%s, %s, %s)",
-                (animal_id, data_ref, peso_entrada)
-            )
-        return animal_id
+        return _inserir_animal(cursor, brinco, sexo, data_compra, preco_compra, peso_entrada,
+                               user_id, data_nascimento, mae_id, pai_id, raca)
 
 
 def registrar_venda(animal_id, user_id, data_venda, preco_venda, peso_venda):

--- a/repositories/reproducao_repository.py
+++ b/repositories/reproducao_repository.py
@@ -1,8 +1,9 @@
 from db_config import get_db_cursor
 from datetime import timedelta, date, datetime
+from repositories.animal_repository import _inserir_animal
 
 
-def insert_reproducao(user_id, vaca_id, touro_id, touro_externo, data_cobertura, data_parto, resultado):
+def _inserir_reproducao(cursor, user_id, vaca_id, touro_id, touro_externo, data_cobertura, data_parto, resultado):
     if isinstance(data_cobertura, str):
         data_cobertura_obj = datetime.strptime(data_cobertura, '%Y-%m-%d').date()
     else:
@@ -10,17 +11,44 @@ def insert_reproducao(user_id, vaca_id, touro_id, touro_externo, data_cobertura,
 
     data_parto_prevista = data_cobertura_obj + timedelta(days=285)
 
+    cursor.execute(
+        "INSERT INTO reproducao "
+        "(user_id, vaca_id, touro_id, touro_externo, data_cobertura, "
+        " data_parto, resultado, data_parto_prevista) "
+        "VALUES (%s, %s, %s, %s, %s, %s, %s, %s)",
+        (user_id, vaca_id, touro_id or None, touro_externo or None,
+         data_cobertura, data_parto or None, resultado,
+         data_parto_prevista)
+    )
+    return cursor.lastrowid
+
+
+def insert_reproducao(user_id, vaca_id, touro_id, touro_externo, data_cobertura, data_parto, resultado):
     with get_db_cursor() as cursor:
-        cursor.execute(
-            "INSERT INTO reproducao "
-            "(user_id, vaca_id, touro_id, touro_externo, data_cobertura, "
-            " data_parto, resultado, data_parto_prevista) "
-            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s)",
-            (user_id, vaca_id, touro_id or None, touro_externo or None,
-             data_cobertura, data_parto or None, resultado,
-             data_parto_prevista)
-        )
-        return cursor.lastrowid
+        return _inserir_reproducao(cursor, user_id, vaca_id, touro_id, touro_externo,
+                                   data_cobertura, data_parto, resultado)
+
+
+def registrar_parto_com_bezerro(user_id, vaca_id, touro_id, touro_externo, data_cobertura,
+                                data_parto, resultado, brinco_bezerro=None, sexo_bezerro=None):
+    """Registra o evento reprodutivo e, se houver parto vivo com dados do bezerro,
+    cadastra o bezerro na MESMA transação — insert_reproducao() e cadastrar_animal()
+    rodavam em transações separadas, então uma falha no segundo insert deixava um
+    registro de parto vivo sem o animal correspondente.
+
+    Retorna (reproducao_id, bezerro_id ou None).
+    """
+    with get_db_cursor() as cursor:
+        reproducao_id = _inserir_reproducao(cursor, user_id, vaca_id, touro_id, touro_externo,
+                                            data_cobertura, data_parto, resultado)
+        bezerro_id = None
+        if resultado == 'vivo' and data_parto and brinco_bezerro and sexo_bezerro:
+            bezerro_id = _inserir_animal(
+                cursor, brinco_bezerro, sexo_bezerro,
+                data_compra=None, preco_compra=None, peso_entrada=None,
+                user_id=user_id, data_nascimento=data_parto, mae_id=vaca_id,
+            )
+        return reproducao_id, bezerro_id
 
 
 def get_reproducao_by_vaca(vaca_id, user_id):

--- a/routes/operacional.py
+++ b/routes/operacional.py
@@ -564,7 +564,10 @@ def registrar_reproducao():
             flash(e, 'error')
         return redirect(url_for('operacional.reproducao_animal', id_animal=id_animal))
 
-    reproducao_repository.insert_reproducao(
+    criar_bezerro = (resultado == 'vivo' and data_parto and brinco_bezerro and sexo_bezerro
+                     and not animal_repository.check_brinco_exists(brinco_bezerro, current_user.id))
+
+    _, bezerro_id = reproducao_repository.registrar_parto_com_bezerro(
         current_user.id,
         id_animal,
         int(touro_id_raw) if touro_id_raw else None,
@@ -572,18 +575,13 @@ def registrar_reproducao():
         request.form.get('data_cobertura'),
         data_parto,
         resultado,
+        brinco_bezerro=brinco_bezerro if criar_bezerro else None,
+        sexo_bezerro=sexo_bezerro if criar_bezerro else None,
     )
 
     bezerro_msg = ''
     if resultado == 'vivo' and data_parto and brinco_bezerro and sexo_bezerro:
-        if not animal_repository.check_brinco_exists(brinco_bezerro, current_user.id):
-            bezerro_id = animal_repository.cadastrar_animal(
-                brinco_bezerro, sexo_bezerro,
-                data_compra=None, preco_compra=None, peso_entrada=None,
-                user_id=current_user.id,
-                data_nascimento=data_parto,
-                mae_id=id_animal,
-            )
+        if bezerro_id:
             bezerro_msg = f' Bezerro criado automaticamente: brinco {brinco_bezerro} (ID #{bezerro_id}).'
         else:
             bezerro_msg = f' Brinco {brinco_bezerro} já existia — bezerro não duplicado.'

--- a/tests/test_reproducao.py
+++ b/tests/test_reproducao.py
@@ -134,6 +134,44 @@ def test_multiplos_eventos_ordenados(um):
 
 # ── Isolamento multi-tenant ───────────────────────────────────────────────────
 
+def test_registrar_parto_com_bezerro_cria_ambos(um):
+    vaca_id = _make_animal(um, sexo="F")
+    brinco_bezerro = f"BEZ{_n()}"
+    rep_id, bezerro_id = reproducao_repository.registrar_parto_com_bezerro(
+        um, vaca_id, None, None, "2024-01-01", "2024-10-15", "vivo",
+        brinco_bezerro=brinco_bezerro, sexo_bezerro="F",
+    )
+    assert rep_id is not None
+    assert bezerro_id is not None
+
+    bezerro = animal_repository.get_animal_by_id(bezerro_id, um)
+    assert bezerro is not None
+    assert bezerro[1] == brinco_bezerro  # índice 1 = brinco
+
+    eventos = reproducao_repository.get_reproducao_by_vaca(vaca_id, um)
+    assert any(e[0] == rep_id for e in eventos)
+
+
+def test_registrar_parto_com_bezerro_brinco_duplicado_faz_rollback_da_reproducao(um):
+    """Cenário de falha do #18: se o insert do bezerro falha (brinco duplicado),
+    o insert da reprodução tem que ser desfeito junto — não pode sobrar um
+    registro de 'parto vivo' sem o bezerro correspondente."""
+    vaca_id = _make_animal(um, sexo="F")
+    brinco_dup = f"DUP{_n()}"
+    _make_animal(um, sexo="M", brinco=brinco_dup)  # já ocupa o brinco
+
+    eventos_antes = reproducao_repository.get_reproducao_by_vaca(vaca_id, um)
+
+    with pytest.raises(Exception):
+        reproducao_repository.registrar_parto_com_bezerro(
+            um, vaca_id, None, None, "2024-01-01", "2024-10-15", "vivo",
+            brinco_bezerro=brinco_dup, sexo_bezerro="F",
+        )
+
+    eventos_depois = reproducao_repository.get_reproducao_by_vaca(vaca_id, um)
+    assert len(eventos_depois) == len(eventos_antes)  # nada foi commitado
+
+
 def test_isolamento_reproducao_por_user(dois):
     uid_a, uid_b = dois
     vaca_a = _make_animal(uid_a, sexo="F")
@@ -259,6 +297,27 @@ def test_registrar_reproducao_post(app):
         assert r.status_code == 200
         eventos = reproducao_repository.get_reproducao_by_vaca(vaca_id, uid)
         assert len(eventos) == 1
+        _purge(uid)
+
+
+def test_registrar_reproducao_post_parto_vivo_cria_bezerro(app):
+    with app.test_client() as client:
+        uid = _make_user()
+        vaca_id = _make_animal(uid, sexo="F")
+        brinco_bezerro = f"BEZHTTP{_n()}"
+        _login(client, uid)
+        r = client.post("/reproducao", data={
+            "vaca_id": vaca_id,
+            "touro_id": "",
+            "touro_externo": "Touro Externo Teste",
+            "data_cobertura": "2024-01-01",
+            "data_parto": "2024-10-15",
+            "resultado": "vivo",
+            "brinco_bezerro": brinco_bezerro,
+            "sexo_bezerro": "F",
+        }, follow_redirects=True)
+        assert r.status_code == 200
+        assert animal_repository.check_brinco_exists(brinco_bezerro, uid) is True
         _purge(uid)
 
 


### PR DESCRIPTION
## Sumário
`insert_reproducao()` e `cadastrar_animal()` rodavam em transações/commits separados ao registrar um parto vivo — uma falha na criação do bezerro (brinco duplicado, FK, queda de conexão) deixava um registro de reprodução "vivo" órfão, sem rollback.

Extrai a lógica de INSERT de ambas as funções para variantes que aceitam um cursor externo (`_inserir_animal`, `_inserir_reproducao`), e adiciona `reproducao_repository.registrar_parto_com_bezerro()`, que abre uma única transação para as duas escritas.

Closes #18

## Test plan
- [x] `pytest tests/` — 274 passed
- [x] Teste específico do cenário de falha: força brinco duplicado no insert do bezerro e confirma que o insert da reprodução (que rodou primeiro, na mesma transação) é desfeito junto — `test_registrar_parto_com_bezerro_brinco_duplicado_faz_rollback_da_reproducao`
- [x] Teste de rota HTTP confirmando que o fluxo normal (parto vivo + bezerro) ainda funciona ponta a ponta