### PR TITLE
Sessão 9: reavaliação da issue #6 — cache não é necessário, causa raiz corrigida em SQL

### DIFF
--- a/repositories/animal_repository.py
+++ b/repositories/animal_repository.py
@@ -421,18 +421,17 @@ def get_animais_abaixo_gmd_medio(user_id, sexo=None, origem=None):
             "      ELSE NULL END AS gmd"
             "  FROM pu WHERE data_ini <> data_fim"
             " ),"
-            " stats AS ("
-            "  SELECT animal_id, gmd,"
-            "    AVG(gmd) OVER () AS gmd_media,"
-            "    STDDEV_POP(gmd) OVER () AS gmd_std"
+            " agg AS ("
+            "  SELECT AVG(gmd) AS gmd_media, STDDEV_POP(gmd) AS gmd_std"
             "  FROM gmd_calc WHERE gmd IS NOT NULL"
             " )"
-            " SELECT s.animal_id, a.brinco, s.gmd, s.gmd_media,"
-            "  s.gmd_std, (s.gmd_media - 2 * s.gmd_std) AS limite_inferior"
-            " FROM stats s"
-            " JOIN animais a ON a.id = s.animal_id"
-            " WHERE s.gmd < (s.gmd_media - 2 * s.gmd_std)"
-            " ORDER BY s.gmd ASC",
+            " SELECT gc.animal_id, a.brinco, gc.gmd, agg.gmd_media,"
+            "  agg.gmd_std, (agg.gmd_media - 2 * agg.gmd_std) AS limite_inferior"
+            " FROM gmd_calc gc"
+            " CROSS JOIN agg"
+            " JOIN animais a ON a.id = gc.animal_id"
+            " WHERE gc.gmd IS NOT NULL AND gc.gmd < (agg.gmd_media - 2 * agg.gmd_std)"
+            " ORDER BY gc.gmd ASC",
             tuple(params)
         )
         return cursor.fetchall()

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -246,6 +246,23 @@ def test_get_gmd_medio_rebanho_filtra_por_sexo(um):
     assert gmd_f < gmd_todos < gmd_m
 
 
+def test_get_animais_abaixo_gmd_medio_identifica_outlier(um):
+    """Animal com GMD muito abaixo da média - 2σ do rebanho deve aparecer como
+    outlier; animais dentro da faixa normal não devem aparecer."""
+    normais = [_make_animal(um) for _ in range(5)]
+    for aid, peso in zip(normais, [452.0, 450.0, 455.0, 448.0, 453.0]):
+        _make_pesagem(aid, peso=peso)  # GMD ~1.0 kg/dia
+
+    outlier = _make_animal(um)
+    _make_pesagem(outlier, peso=305.0)  # GMD ~0.03 kg/dia — crescimento estagnado
+
+    resultado = animal_repository.get_animais_abaixo_gmd_medio(um)
+    ids_outliers = {row[0] for row in resultado}
+
+    assert outlier in ids_outliers
+    assert not (set(normais) & ids_outliers)
+
+
 def test_count_animais_status_todos_igual_ativos_mais_vendidos(um):
     aid_v = _make_animal(um)
     _make_animal(um)  # ativo


### PR DESCRIPTION
## Reavaliação

Antes de implementar cache/pré-processamento (proposta original da issue, incluindo Redis), medi o tempo real das queries por trás de `/painel`, `/api/dashboard-summary`, `/financeiro`, `/pastos` e `/estoque` com um rebanho sintético de 3000 animais (~6000 pesagens) e 3000 lançamentos financeiros/ano, usando um script de benchmark descartável contra o banco de teste local (sem tocar produção).

**Resultado:** depois das correções das Sessões 1-8, praticamente tudo já roda abaixo de 15ms. A única exceção era `get_animais_abaixo_gmd_medio` (usada em todo carregamento do painel via `/api/dashboard-summary`), em ~600ms.

**Causa raiz:** `AVG(gmd) OVER ()` e `STDDEV_POP(gmd) OVER ()` sem `PARTITION BY` — o MariaDB materializa e reordena o CTE inteiro como window frame em vez de computar a média/desvio como agregado escalar de uma passada. `EXPLAIN` mostrava múltiplos `<derived>` com `Using temporary; Using filesort` empilhados.

## Fix

Troca a CTE `stats` (com as duas window functions) por um `CROSS JOIN` com uma subquery de agregado escalar (`agg AS (SELECT AVG(gmd), STDDEV_POP(gmd) ...)`) — mesmo resultado, ~27ms (23x mais rápido).

## Decisão: sem cache

Com esse fix, o pior caso de carregamento fica na casa de poucas dezenas de ms, mesmo em um rebanho bem acima do "poucas dezenas" típico documentado no CLAUDE.md. Não há benefício real mensurável em adicionar uma camada de cache (em memória ou Redis) por cima disso agora — seria complexidade nova (invalidação, staleness, Redis como dependência de infra) para resolver um problema que não existe mais, contrariando tanto o YAGNI quanto a recomendação explícita do CLAUDE.md contra Redis para esse tipo de cache.

Closes #6

## Test plan
- [x] `pytest tests/` — 287 passed (1 teste novo cobrindo a detecção de outlier de GMD, que não tinha teste dedicado)
- [x] Benchmark antes/depois documentado no commit (600ms → 27ms na query afetada; todas as demais já sub-15ms)