### PR TITLE
fix: tratamento de erro nas rotas operacionais

### DIFF
--- a/routes/operacional.py
+++ b/routes/operacional.py
@@ -41,6 +41,7 @@ def painel():
         alertas_sanitarios = sanitario_repository.get_vencendo_em_dias(current_user.id, dias=7)
     except Exception as e:
         logger.error(f"Erro painel: {e}", exc_info=True)
+        flash("Não foi possível carregar o rebanho agora. Tente novamente em instantes.", 'error')
 
     return render_template("index.html", lista_animais=animais, pagina_atual=pg,
                            total_paginas=total_pg, total_animais=total, busca=termo, status=status,
@@ -64,6 +65,7 @@ def lixeira():
             total_pg = math.ceil(total / limit)
     except Exception as e:
         logger.error(f"Erro lixeira: {e}", exc_info=True)
+        flash("Não foi possível carregar a lixeira agora. Tente novamente em instantes.", 'error')
 
     return render_template("lixeira.html", lista_animais=animais, pagina_atual=pg, total_paginas=total_pg, busca=termo)
 
@@ -128,9 +130,17 @@ def cadastro():
             )
             flash(f"Animal {brinco} cadastrado com sucesso.", 'success')
             return redirect(url_for('operacional.detalhes', id_animal=new_id))
+        except _mysql_errors.IntegrityError:
+            # UNIQUE (brinco, user_id) conta linhas soft-deletadas, que
+            # check_brinco_exists ignora — o brinco pode estar na lixeira.
+            logger.warning("IntegrityError cadastro (brinco duplicado) user=%s", current_user.id)
+            return render_template(
+                "cadastro.html",
+                mensagem="Já existe um animal com esse brinco. Verifique a lixeira — ele pode estar excluído.",
+                form_data=request.form), 400
         except Exception as e:
             logger.error(f"Erro cadastro: {e}", exc_info=True)
-            msg = f"Erro: {e}"
+            msg = "Não foi possível cadastrar o animal. Tente novamente."
     return render_template("cadastro.html", mensagem=msg)
 
 @operacional_bp.route('/animal/<int:id_animal>')
@@ -166,6 +176,7 @@ def detalhes(id_animal):
                                historico_med=meds, indicadores=kpis, idade_meses=idade_meses)
     except Exception as e:
         logger.error(f"Erro detalhes: {e}", exc_info=True)
+        flash("Não foi possível carregar os dados do animal agora. Tente novamente.", 'error')
         return redirect(url_for('operacional.painel'))
 
 @operacional_bp.route('/vender/<int:id_animal>', methods=['GET', 'POST'])

--- a/tests/test_operacional.py
+++ b/tests/test_operacional.py
@@ -58,6 +58,31 @@ def test_validacao_cadastro_duplicado(client):
     # Verifica se a mensagem de erro aparece
     assert b"Erro" in response.data or b"existe" in response.data
 
+def test_cadastro_brinco_na_lixeira_mensagem_amigavel(client):
+    """Issue #32 — recadastrar brinco de animal soft-deletado bate na UNIQUE KEY;
+    a rota deve mostrar mensagem amigável (aponta a lixeira), não o erro cru do MySQL."""
+    login(client)
+    client.post('/cadastro', data={
+        'brinco': 'LIXO-BRINCO', 'sexo': 'M', 'data_compra': '2024-01-01',
+        'peso_compra': '300', 'valor_arroba': '250',
+    })
+    row = _fetch_one("SELECT id FROM animais WHERE brinco='LIXO-BRINCO' AND deleted_at IS NULL")
+    assert row is not None
+    conn = dbc.get_db_connection()
+    cur = conn.cursor()
+    cur.execute("UPDATE animais SET deleted_at = NOW() WHERE id = %s", (row[0],))
+    conn.commit(); cur.close(); conn.close()
+
+    response = client.post('/cadastro', data={
+        'brinco': 'LIXO-BRINCO', 'sexo': 'M', 'data_compra': '2024-02-01',
+        'peso_compra': '310', 'valor_arroba': '250',
+    })
+    assert response.status_code == 400
+    text = response.data.decode('utf-8')
+    assert 'lixeira' in text.lower()
+    assert 'IntegrityError' not in text and 'Duplicate' not in text
+
+
 def test_venda_animal(client):
     """Cadastra e Vende um animal, verificando a baixa de estoque."""
     login(client)


### PR DESCRIPTION
- **Closes #32** — recadastrar um brinco que está na lixeira batia na `UNIQUE KEY (brinco, user_id)` e vazava o `IntegrityError` cru do MySQL (`msg = f"Erro: {e}"`). Agora `cadastro()` captura `IntegrityError` com mensagem amigável apontando a lixeira e a mensagem genérica deixa de expor detalhe interno em qualquer exceção.
- **Closes #36** — o `except Exception` amplo em `painel`/`lixeira`/`detalhes` renderizava lista vazia sem aviso (parece perda de dados). Agora dá `flash()` de erro, distinguindo vazio-por-falha de rebanho realmente vazio.

Teste de regressão para #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)