### PR TITLE
chore: limpezas de tech-debt (PDFs órfãos, filtro morto)

### DIFF
--- a/repositories/animal_repository.py
+++ b/repositories/animal_repository.py
@@ -164,7 +164,7 @@ def get_lotes(user_id):
     with get_db_cursor() as cursor:
         cursor.execute(
             "SELECT id, codigo_lote FROM lotes "
-            "WHERE user_id = %s AND deleted_at IS NULL "
+            "WHERE user_id = %s "
             "ORDER BY data_aquisicao DESC",
             (user_id,)
         )

--- a/routes/api.py
+++ b/routes/api.py
@@ -51,7 +51,25 @@ _MAPA_ESTADOS = {
 }
 
 _PDF_DIR = '/tmp'
+_PDF_MAX_AGE = 3600  # 1h — jobs abandonados (.pdf/.error/.pending) viram lixo em /tmp
 _UUID_RE = _re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$')
+
+
+def _limpar_pdfs_orfaos() -> None:
+    """Remove sgg_pdf_* com mais de 1h ao criar um job novo — limpeza
+    oportunística, sem worker/cron dedicado.
+    ponytail: best-effort, nunca propaga erro para a geração do relatório."""
+    corte = time.time() - _PDF_MAX_AGE
+    try:
+        with _os.scandir(_PDF_DIR) as it:
+            for entry in it:
+                if entry.name.startswith('sgg_pdf_') and entry.stat().st_mtime < corte:
+                    try:
+                        _os.remove(entry.path)
+                    except OSError:
+                        pass
+    except OSError:
+        pass
 
 
 def _csv_response(filename: str, header: list, rows: list) -> Response:
@@ -241,6 +259,7 @@ def relatorio_pdf():
                            gmd_medio=gmd_medio,
                            data_geracao=date.today().strftime('%d/%m/%Y'))
 
+    _limpar_pdfs_orfaos()
     job_id = str(uuid.uuid4())
     jobs = session.get('pdf_jobs', [])
     jobs = (jobs[-9:] if len(jobs) >= 10 else jobs) + [job_id]

--- a/tests/test_pdf_cleanup.py
+++ b/tests/test_pdf_cleanup.py
@@ -1,0 +1,28 @@
+"""Issue #37 — limpeza oportunística de PDFs órfãos em /tmp."""
+import os
+import time
+
+from routes.api import _limpar_pdfs_orfaos, _PDF_DIR, _PDF_MAX_AGE
+
+
+def _touch(nome, idade_seg):
+    caminho = os.path.join(_PDF_DIR, nome)
+    open(caminho, 'w').close()
+    t = time.time() - idade_seg
+    os.utime(caminho, (t, t))
+    return caminho
+
+
+def test_limpa_orfaos_antigos_preserva_recentes_e_alheios():
+    velho   = _touch('sgg_pdf_teste_velho.pending', _PDF_MAX_AGE + 120)
+    novo    = _touch('sgg_pdf_teste_novo.pending', 10)
+    alheio  = _touch('outro_arquivo_qualquer.tmp', _PDF_MAX_AGE + 120)
+    try:
+        _limpar_pdfs_orfaos()
+        assert not os.path.exists(velho)      # órfão antigo removido
+        assert os.path.exists(novo)           # job recente intacto
+        assert os.path.exists(alheio)         # não toca em arquivos de terceiros
+    finally:
+        for p in (velho, novo, alheio):
+            if os.path.exists(p):
+                os.remove(p)


### PR DESCRIPTION
- **Closes #37** — `relatorio_pdf` passa a fazer limpeza oportunística de `sgg_pdf_*` com mais de 1h ao criar um job novo, evitando acúmulo de PDFs órfãos em `/tmp` (sem worker/cron novo).
- **Closes #39** — remove o filtro morto `deleted_at IS NULL` de `get_lotes`: nada no código faz soft delete de lote, a coluna existe mas nunca é preenchida. Optei por simplificar em vez de implementar uma feature que ninguém pediu.

Teste self-contained para a limpeza de #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)