### PR TITLE
fix: normaliza raça na escrita para evitar duplicatas no filtro (#44)

### DIFF
--- a/repositories/animal_repository.py
+++ b/repositories/animal_repository.py
@@ -2,6 +2,17 @@ from db_config import get_db_cursor
 from datetime import datetime
 
 
+def _normalizar_raca(raca):
+    """Canonicaliza raça antes de gravar: trim, colapsa espaços e Title Case.
+
+    Ponto único de higienização — evita que "nelore ", "NELORE" e "Nelore"
+    virem linhas distintas no dropdown/filtro do painel. Retorna None p/ vazio.
+    """
+    if not raca:
+        return None
+    return ' '.join(raca.split()).title() or None
+
+
 # ATENÇÃO: `conds` deve conter apenas literais hardcoded (ex.: "deleted_at IS NULL").
 # Dados externos (usuário, banco, request) nunca devem ser interpolados em `conds` —
 # sempre vão para `params` e chegam ao banco via placeholder %s.
@@ -589,7 +600,7 @@ def _inserir_animal(cursor, brinco, sexo, data_compra, preco_compra, peso_entrad
         "INSERT INTO animais "
         "(brinco, sexo, raca, data_compra, data_nascimento, preco_compra, user_id, mae_id, pai_id) "
         "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)",
-        (brinco, sexo, raca or None, data_compra or None, data_nascimento or None,
+        (brinco, sexo, _normalizar_raca(raca), data_compra or None, data_nascimento or None,
          preco_compra or None, user_id, mae_id or None, pai_id or None)
     )
     animal_id = cursor.lastrowid
@@ -787,7 +798,7 @@ def cadastrar_lote(user_id, codigo_lote, descricao, data_compra, animais_data, r
         cursor.executemany(
             "INSERT INTO animais (brinco, sexo, raca, data_compra, preco_compra, user_id, lote_id) "
             "VALUES (%s, %s, %s, %s, %s, %s, %s)",
-            [(brinco, sexo, raca or None, data_compra, custo_animal, user_id, lote_id)
+            [(brinco, sexo, _normalizar_raca(raca), data_compra, custo_animal, user_id, lote_id)
              for brinco, sexo, peso, custo_animal in animais_data]
         )
 

--- a/routes/operacional.py
+++ b/routes/operacional.py
@@ -708,7 +708,7 @@ def importar_csv():
                 brinco      = (row.get('brinco') or '').strip()
                 sexo        = (row.get('sexo') or '').strip().upper()
                 data_compra = (row.get('data_compra') or '').strip()
-                raca        = (row.get('raca') or '').strip() or None
+                raca        = animal_repository._normalizar_raca(row.get('raca'))
                 data_nasc   = (row.get('data_nascimento') or '').strip() or None
 
                 linha_erros = []

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -223,6 +223,24 @@ def test_cadastrar_animal_cria_pesagem_inicial(um):
     assert float(pesagens[0][3]) == pytest.approx(280.0)  # índice 3 = peso
 
 
+def test_normalizar_raca_canonicaliza_variacoes():
+    """Trim, colapso de espaços e Title Case reduzem variações à mesma forma."""
+    assert animal_repository._normalizar_raca("nelore ") == "Nelore"
+    assert animal_repository._normalizar_raca("NELORE") == "Nelore"
+    assert animal_repository._normalizar_raca("  red  angus ") == "Red Angus"
+    assert animal_repository._normalizar_raca("") is None
+    assert animal_repository._normalizar_raca(None) is None
+
+
+def test_get_racas_distintas_agrupa_variacoes(um):
+    """Duas grafias da mesma raça na escrita → um único valor no dropdown."""
+    animal_repository.cadastrar_animal(f"RC{_n()}", "F", "2024-01-01", 1000.0, 280.0, um, raca="nelore ")
+    animal_repository.cadastrar_animal(f"RC{_n()}", "M", "2024-01-01", 1000.0, 280.0, um, raca="NELORE")
+    racas = animal_repository.get_racas_distintas(um)
+    assert racas.count("Nelore") == 1
+    assert "nelore " not in racas and "NELORE" not in racas
+
+
 def test_cadastrar_lote_associa_pesagem_ao_animal_correto(um):
     """cadastrar_lote insere animais e pesagens via executemany, mapeando o
     animal_id de volta por brinco — cada pesagem tem que ficar com o animal certo,


### PR DESCRIPTION
## Problema
`animais.raca` é texto livre. Sem normalização na escrita, `"Nelore"`, `"nelore"`, `"NELORE"` e `"Nelore "` viram 4 valores distintos — poluindo o dropdown de filtro do painel, fazendo o filtro exato perder linhas e fragmentando agrupamentos por raça.

## Causa raiz
Três caminhos de escrita de `raca` inseriam o valor cru, sem ponto único de canonicalização:
1. `_inserir_animal` (cadastro individual + bezerro da reprodução)
2. `cadastrar_lote`
3. `importar_csv` (bulk insert)

## Solução
Helper único `_normalizar_raca` em `animal_repository.py` (trim + colapsa espaços internos + Title Case), aplicado nos três pontos de escrita. Sem tabela nova, sem trigger — lógica em Python/repository, no estilo do projeto.

## Testes
- `test_normalizar_raca_canonicaliza_variacoes` — unit puro do helper
- `test_get_racas_distintas_agrupa_variacoes` — dois animais `"nelore "`/`"NELORE"` → um único `"Nelore"` no dropdown

Ambos passam localmente.

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)