### PR TITLE
fix: exclusão de conta apaga o tenant inteiro em ordem de dependência (#45)

### DIFF
--- a/repositories/auth_repository.py
+++ b/repositories/auth_repository.py
@@ -58,3 +58,43 @@ def update_password(user_id, new_hash):
             "UPDATE usuarios SET password_hash = %s WHERE id = %s",
             (new_hash, user_id)
         )
+
+
+def delete_user_and_data(user_id):
+    """Apaga o tenant inteiro em uma única transação, na ordem de dependência.
+
+    A maioria das FKs para usuarios(id) é RESTRICT (sem ON DELETE CASCADE),
+    então um DELETE direto em usuarios falha (errno 1451) se houver qualquer
+    dado. Removemos os filhos primeiro. Tabelas com CASCADE a partir de
+    usuarios (pastos, estoque_produtos, protocolos_sanitarios,
+    password_reset_tokens) e a partir de animais (ocupacao_animais) somem
+    junto — mas as intermediárias com user_id RESTRICT (modulos, ocupacoes,
+    estoque_movimentacoes, reproducao) precisam ser apagadas explicitamente.
+    """
+    # Ordem: netos → filhos → tabelas diretas de usuarios → usuarios.
+    comandos = [
+        # filhos de animais que bloqueiam o DELETE de animais (RESTRICT)
+        "DELETE p FROM pesagens p JOIN animais a ON p.animal_id = a.id WHERE a.user_id = %s",
+        "DELETE m FROM medicacoes m JOIN animais a ON m.animal_id = a.id WHERE a.user_id = %s",
+        "DELETE FROM reproducao WHERE user_id = %s",
+        # cadeia de pastos (ocupacao_animais cascateia de ocupacoes)
+        "DELETE FROM ocupacoes WHERE user_id = %s",
+        "DELETE FROM modulos WHERE user_id = %s",
+        "DELETE FROM pastos WHERE user_id = %s",
+        # animais antes de lotes (animais.lote_id é RESTRICT)
+        "DELETE FROM animais WHERE user_id = %s",
+        "DELETE FROM lotes WHERE user_id = %s",
+        # estoque
+        "DELETE FROM estoque_movimentacoes WHERE user_id = %s",
+        "DELETE FROM estoque_produtos WHERE user_id = %s",
+        # tabelas diretas de usuarios
+        "DELETE FROM custos_operacionais WHERE user_id = %s",
+        "DELETE FROM configuracoes WHERE user_id = %s",
+        "DELETE FROM financial_schedule WHERE user_id = %s",
+        "DELETE FROM protocolos_sanitarios WHERE user_id = %s",
+        "DELETE FROM password_reset_tokens WHERE user_id = %s",
+        "DELETE FROM usuarios WHERE id = %s",
+    ]
+    with get_db_cursor() as cursor:
+        for sql in comandos:
+            cursor.execute(sql, (user_id,))

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -275,8 +275,7 @@ def apagar_conta():
 
     user_id = current_user.id
     try:
-        with get_db_cursor() as cursor:
-            cursor.execute("DELETE FROM usuarios WHERE id = %s", (user_id,))
+        auth_repository.delete_user_and_data(user_id)
         logout_user()
         session.clear()
         flash('Conta excluída com sucesso.', 'success')

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -7,7 +7,7 @@ import itertools
 from datetime import date, timedelta
 from werkzeug.security import generate_password_hash
 import db_config as dbc
-from repositories import animal_repository, financeiro_repository, configuracao_repository
+from repositories import animal_repository, financeiro_repository, configuracao_repository, auth_repository
 
 _seq = itertools.count(1000)
 
@@ -221,6 +221,25 @@ def test_cadastrar_animal_cria_pesagem_inicial(um):
     pesagens = animal_repository.get_pesagens_by_animal(aid)
     assert len(pesagens) == 1
     assert float(pesagens[0][3]) == pytest.approx(280.0)  # índice 3 = peso
+
+
+def test_delete_user_and_data_remove_tudo_com_fk_restrict(app):
+    """Issue #45 — DELETE direto em usuarios falha por FK RESTRICT quando há
+    dados. delete_user_and_data apaga na ordem certa (pesagens→animais→lotes)
+    e o usuário some junto com seus animais."""
+    uid = _make_user()
+    # cadastrar_lote cria lote + animais + pesagens: exercita o caminho RESTRICT
+    animal_repository.cadastrar_lote(uid, f"DL{_n()}", "Lote", "2024-01-01", [
+        (f"DL{_n()}A", "M", 250.0, 900.0),
+        (f"DL{_n()}B", "F", 300.0, 1100.0),
+    ])
+    assert _count("SELECT COUNT(*) FROM animais WHERE user_id = %s", (uid,)) == 2
+
+    auth_repository.delete_user_and_data(uid)
+
+    assert _count("SELECT COUNT(*) FROM usuarios WHERE id = %s", (uid,)) == 0
+    assert _count("SELECT COUNT(*) FROM animais WHERE user_id = %s", (uid,)) == 0
+    assert _count("SELECT COUNT(*) FROM lotes WHERE user_id = %s", (uid,)) == 0
 
 
 def test_cadastrar_lote_associa_pesagem_ao_animal_correto(um):


### PR DESCRIPTION
## Problema
`apagar_conta` fazia um único `DELETE FROM usuarios WHERE id = %s`. Como a maioria das FKs para `usuarios(id)` é RESTRICT (sem `ON DELETE CASCADE`), o MySQL bloqueava o DELETE (errno 1451) sempre que o usuário tivesse qualquer dado — a exclusão sempre caía no `except`. Além do bug funcional, é um problema de direito à exclusão (LGPD).

## Causa raiz
FKs RESTRICT em `animais`, `lotes`, `custos_operacionais`, `configuracoes`, `financial_schedule`, `modulos`, `ocupacoes`, `reproducao`, `estoque_movimentacoes`.

## Solução
`auth_repository.delete_user_and_data(user_id)` — apaga o tenant inteiro em **uma transação**, na ordem de dependência (filhos → pais):
`pesagens`/`medicacoes`/`reproducao` → cadeia de pastos → `animais` antes de `lotes` → estoque → tabelas diretas de `usuarios` → `usuarios`. Tabelas com CASCADE somem junto no DELETE final; as intermediárias RESTRICT são apagadas explicitamente. **Sem migração de schema** (opção recomendada na issue).

SQL fica no repository, seguindo a convenção do projeto.

## Teste
`test_delete_user_and_data_remove_tudo_com_fk_restrict` — cria lote+animais+pesagens (caminho RESTRICT real, sem desabilitar FK checks) e assere que usuário, animais e lotes somem. Passa localmente.

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)