### PR TITLE
fix: hardening de cookies de sessão + CSP/HSTS + guard de SECRET_KEY (#46)

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,8 +18,30 @@ from repositories import configuracao_repository
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
+_DEBUG = os.getenv('FLASK_DEBUG', 'False') == 'True'
+
 app = Flask(__name__)
 app.secret_key = os.getenv('SECRET_KEY')
+if not app.secret_key:
+    # Sem SECRET_KEY as sessões/CSRF ficam inseguras. Em produção é erro fatal;
+    # em dev gera uma chave efêmera para não travar quem ainda não tem .env.
+    if _DEBUG:
+        import secrets as _secrets
+        app.secret_key = _secrets.token_hex(32)
+        logging.getLogger(__name__).warning("SECRET_KEY ausente — usando chave efêmera de dev.")
+    else:
+        raise RuntimeError("SECRET_KEY não definido — defina-o no ambiente antes do deploy.")
+
+# Cookies de sessão: HttpOnly + SameSite sempre; Secure em produção (HTTPS).
+# Em dev sobre HTTP o Secure quebraria o login, então segue o FLASK_DEBUG.
+_cookie_secure = os.getenv('SESSION_COOKIE_SECURE', 'false' if _DEBUG else 'true') == 'true'
+app.config.update(
+    SESSION_COOKIE_SECURE=_cookie_secure,
+    SESSION_COOKIE_HTTPONLY=True,
+    SESSION_COOKIE_SAMESITE='Lax',
+    REMEMBER_COOKIE_SECURE=_cookie_secure,
+    REMEMBER_COOKIE_HTTPONLY=True,
+)
 csrf = CSRFProtect(app)
 limiter.init_app(app)
 compress.init_app(app)
@@ -86,11 +108,34 @@ def set_static_cache(response):
         response.cache_control.public = True
     return response
 
+# CSP alinhada ao que o front realmente carrega: scripts/estilos inline (o app
+# usa <script> e handlers inline em vários templates → precisa de 'unsafe-inline'),
+# echarts via jsDelivr, fontes do Google. Toda chamada fetch é same-origin.
+# É defesa em profundidade (bloqueia origens externas não listadas), não substitui
+# o escape de dados — ver issue #48.
+_CSP = (
+    "default-src 'self'; "
+    "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+    "font-src 'self' https://fonts.gstatic.com; "
+    "img-src 'self' data:; "
+    "connect-src 'self'; "
+    "frame-ancestors 'self'; "
+    "base-uri 'self'; "
+    "form-action 'self'"
+)
+
 @app.after_request
 def set_security_headers(response):
     response.headers.setdefault('X-Content-Type-Options', 'nosniff')
     response.headers.setdefault('X-Frame-Options', 'SAMEORIGIN')
     response.headers.setdefault('Referrer-Policy', 'strict-origin-when-cross-origin')
+    response.headers.setdefault('Content-Security-Policy', _CSP)
+    # HSTS só faz sentido sob HTTPS; em dev (HTTP) o browser ignoraria de qualquer forma.
+    if not _DEBUG:
+        response.headers.setdefault(
+            'Strict-Transport-Security', 'max-age=31536000; includeSubDomains'
+        )
     return response
 
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -119,6 +119,21 @@ def test_security_headers_em_rota_publica(client):
     assert r.headers.get('X-Frame-Options') == 'SAMEORIGIN'
 
 
+def test_csp_presente_e_restringe_default_src(client):
+    """Issue #46 — CSP como defesa em profundidade."""
+    r = client.get('/login')
+    csp = r.headers.get('Content-Security-Policy')
+    assert csp is not None
+    assert "default-src 'self'" in csp
+    assert "frame-ancestors 'self'" in csp
+
+
+def test_session_cookie_flags_configurados(app):
+    """Issue #46 — HttpOnly + SameSite=Lax na config da sessão."""
+    assert app.config['SESSION_COOKIE_HTTPONLY'] is True
+    assert app.config['SESSION_COOKIE_SAMESITE'] == 'Lax'
+
+
 # ── Grupo B — S1: Rate limit no login ────────────────────────────────────────
 
 def test_login_retorna_429_apos_10_tentativas(app_com_limite, client):


### PR DESCRIPTION
## Problema
Em produção (Railway/HTTPS) o cookie de sessão podia trafegar sem `Secure` e sem `SameSite`, e o app não enviava `Content-Security-Policy` nem `Strict-Transport-Security`. Além disso `SECRET_KEY` ausente era silenciosamente `None`.

## Solução
- **Cookies:** `SESSION_COOKIE_HTTPONLY` + `SAMESITE='Lax'` sempre; `Secure` ligado em produção. Segue `FLASK_DEBUG` (dev sobre HTTP não quebra) com override via `SESSION_COOKIE_SECURE`. Idem `REMEMBER_COOKIE_*`.
- **CSP:** `default-src 'self'`, liberando exatamente o que o front carrega — inline scripts/handlers (`'unsafe-inline'`, presentes em ~35 templates), echarts via jsDelivr, Google Fonts. Todo `fetch` é same-origin (`connect-src 'self'`). Defesa em profundidade; o escape de dados de terceiros é tratado na #48.
- **HSTS:** `max-age=31536000; includeSubDomains` fora de debug.
- **SECRET_KEY:** erro fatal no boot em produção; chave efêmera com warning só em dev.

## Testes
`test_csp_presente_e_restringe_default_src`, `test_session_cookie_flags_configurados` + os headers existentes. Passam localmente.

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)