### PR TITLE
fix: Dockerfile roda gunicorn em vez do dev server flask run (#47)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-EXPOSE 5000
+# gunicorn.conf.py faz bind em 0.0.0.0:$PORT (default 8000)
+EXPOSE 8000
 
-CMD ["flask", "run", "--host=0.0.0.0"]
+CMD ["gunicorn", "-c", "gunicorn.conf.py", "app:app"]


### PR DESCRIPTION
## Problema
O `Dockerfile` terminava com `CMD ["flask", "run", "--host=0.0.0.0"]` — o servidor de desenvolvimento Werkzeug (single-thread, sem hardening, com aviso explícito contra uso em produção). Divergia do `Procfile`/`railway.toml`, que já usam gunicorn. Além disso `flask run` depende de `FLASK_APP` (não setado) e `EXPOSE 5000` divergia da porta do gunicorn.

## Solução
`CMD ["gunicorn", "-c", "gunicorn.conf.py", "app:app"]` e `EXPOSE 8000` (porta default do `bind` em `gunicorn.conf.py`). Qualquer deploy via Dockerfile passa a subir com os 3 workers e o `post_fork` (reinit do pool MySQL + guard do scheduler).

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)