### PR TITLE
fix: escapa dados de cotação/brinco em innerHTML e valida feed externo (#48)

### DIFF
--- a/routes/api.py
+++ b/routes/api.py
@@ -97,7 +97,10 @@ def _fetch_cotacoes_github() -> tuple[list, list]:
     def _get(endpoint: str) -> list:
         try:
             r = requests.get(f"{base}/{endpoint}", timeout=5)
-            return r.json() if r.status_code == 200 else []
+            if r.status_code != 200:
+                return []
+            dados = r.json()
+            return dados if isinstance(dados, list) else []
         except Exception:
             return []
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -328,6 +328,15 @@ const API = {
   csrf:    "{{ csrf_token() }}",
 };
 
+// Escapa strings antes de interpolar em innerHTML — usado para dados que não
+// controlamos totalmente: feed externo de cotações (item.praca) e brinco (texto
+// livre do usuário). Ver issue #48.
+function escHtml(s) {
+  return String(s == null ? '' : s)
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
 async function gerarPDF() {
   const btn = document.getElementById('btn-pdf');
   btn.disabled = true;
@@ -449,7 +458,7 @@ async function carregarMetricas() {
     alertasDiv.innerHTML = '';
 
     if (!alertasData.error && alertasData.total > 0) {
-      const lista  = alertasData.animais.slice(0, 6).map(a => a.brinco).join(', ');
+      const lista  = alertasData.animais.slice(0, 6).map(a => escHtml(a.brinco)).join(', ');
       const mais   = alertasData.total > 6 ? ` e mais ${alertasData.total - 6}` : '';
       const limite = alertasData.gmd_limite_inferior != null
                      ? alertasData.gmd_limite_inferior.toFixed(3)
@@ -553,7 +562,7 @@ function abrirModalBrasil() {
       const pNov = mapaNovilha[item.praca]
         ? parseFloat(mapaNovilha[item.praca]).toFixed(2).replace('.', ',') : '---';
       return `<tr>
-        <td class="praca-nome">${item.praca}</td>
+        <td class="praca-nome">${escHtml(item.praca)}</td>
         <td class="preco-boi">R$ ${pBoi}</td>
         <td class="preco-novilha">R$ ${pNov}</td>
       </tr>`;

--- a/tests/test_dashboard_api.py
+++ b/tests/test_dashboard_api.py
@@ -242,3 +242,19 @@ def test_cotacoes_brasil_retorna_estrutura(app, um):
         assert r.status_code == 200
         data = r.get_json()
         assert 'boi' in data and 'novilha' in data
+
+
+def test_fetch_cotacoes_descarta_json_nao_lista(app, monkeypatch):
+    """Issue #48 — feed externo que retorne JSON válido mas não-lista
+    (ex.: {}) não pode vazar para o front; _get devolve [] nesse caso."""
+    from routes import api as api_mod
+
+    class _FakeResp:
+        status_code = 200
+        def json(self):
+            return {"erro": "<script>alert(1)</script>"}
+
+    monkeypatch.setattr(api_mod.requests, "get", lambda *a, **k: _FakeResp())
+    api_mod._cotacoes_cache['ts'] = 0  # invalida cache p/ forçar fetch
+    boi, novilha = api_mod._fetch_cotacoes_github()
+    assert boi == [] and novilha == []


### PR DESCRIPTION
## Problema
`carregarCotacoesBrasil` e o bloco de alertas GMD em `index.html` interpolavam `item.praca` (JSON de um scraper externo, fora do controle do app) e o `brinco` (texto livre do usuário) diretamente em template strings atribuídas a `innerHTML`, sem escape. Se o feed for comprometido ou um brinco contiver HTML, o markup executa no contexto autenticado.

## Solução
- Helper `escHtml` aplicado aos dois pontos de interpolação não confiáveis (`item.praca`, `brinco`). Valores numéricos (`parseFloat`) e SVG hardcoded permanecem como estão.
- `_fetch_cotacoes_github` passa a descartar resposta que não seja lista JSON (`isinstance(dados, list)`), evitando vazar payload inesperado ao front.

## Teste
`test_fetch_cotacoes_descarta_json_nao_lista` — feed devolvendo `{}` → `([], [])`. O escape client-side não tem harness JS neste repo; validado por revisão de diff.

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)