### PR TITLE
fix: usa KG_POR_ARROBA como fonte única no back e no front (#49)

### DIFF
--- a/app.py
+++ b/app.py
@@ -108,6 +108,14 @@ _CACHE_BUST = _git_sha()
 def inject_cache_bust():
     return {'cache_bust': _CACHE_BUST}
 
+
+@app.context_processor
+def inject_constantes():
+    # Fonte única de KG_POR_ARROBA para o front (utils/calculo.py) — evita
+    # literal 30 duplicado no JS. Ver issue #49.
+    from utils.calculo import KG_POR_ARROBA
+    return {'kg_por_arroba': KG_POR_ARROBA}
+
 @app.route('/')
 def index():
     if current_user.is_authenticated:

--- a/routes/api.py
+++ b/routes/api.py
@@ -14,6 +14,7 @@ from datetime import date
 from playwright.sync_api import sync_playwright
 from repositories import animal_repository, configuracao_repository, financeiro_repository
 from extensions import limiter
+from utils.calculo import KG_POR_ARROBA
 
 api_bp = Blueprint('api', __name__)
 logger = logging.getLogger(__name__)
@@ -172,7 +173,7 @@ def graficos_peso():
     rows = animal_repository.get_pesos_atuais_rebanho(current_user.id)
     cat_peso = {'Menos de 10@': 0, '10@ a 15@': 0, '15@ a 20@': 0, 'Mais de 20@': 0}
     for (p_kg,) in rows:
-        p_arr = float(p_kg) / 30
+        p_arr = float(p_kg) / KG_POR_ARROBA
         if p_arr < 10:
             cat_peso['Menos de 10@'] += 1
         elif 10 <= p_arr < 15:

--- a/static/js/lote-selecao.js
+++ b/static/js/lote-selecao.js
@@ -1,6 +1,6 @@
 // Widget de seleção em lote: checkbox por linha, marcar/desmarcar todos, contagem.
 // Cada página injeta onCheck/onUncheck para o comportamento específico do campo de peso.
-const KG_POR_ARROBA = 30;
+// (KG_POR_ARROBA, quando necessário, é injetado pela própria página via {{ kg_por_arroba }}.)
 
 function initSelecaoLote({ onCheck, onUncheck } = {}) {
   const checks       = document.querySelectorAll('.animal-check');

--- a/templates/venda_lote.html
+++ b/templates/venda_lote.html
@@ -295,6 +295,7 @@
 <script src="{{ url_for('static', filename='js/lote-selecao.js') }}"></script>
 <script>
 (function () {
+  const KG_POR_ARROBA = {{ kg_por_arroba }};  // fonte única: utils/calculo.py
   {% if restore_data and restore_data.animal_ids %}
   const _RESTORE = {
     animal_ids:  {{ restore_data.animal_ids | tojson }},


### PR DESCRIPTION
## Problema
`utils/calculo.py:KG_POR_ARROBA = 30` deveria ser o único ponto de conversão peso↔@, mas o literal `30` estava reescrito no backend (`graficos_peso`) e no front (`lote-selecao.js`). Se a constante mudar, as cópias divergem silenciosamente.

## Solução
- **Backend:** `graficos_peso` importa e usa `KG_POR_ARROBA`.
- **Front:** novo `context_processor` injeta `kg_por_arroba` (a partir da constante Python). `venda_lote.html` — único consumidor real — define `const KG_POR_ARROBA = {{ kg_por_arroba }}`. O `const KG_POR_ARROBA = 30` em `lote-selecao.js` era **código morto** naquele arquivo (nunca referenciado lá) e foi removido.

Fonte única passa a ser `utils/calculo.py` → context → template → JS.

## Verificação
- `test_graficos_peso_classifica_por_arroba` passa.
- Suíte `test_venda_lote.py` (9) passa.
- Render direto de `venda_lote.html` confirma `KG_POR_ARROBA = 30` vindo da constante Python.

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)