### PR TITLE
fix: mitiga enumeração de usuário/email no cadastro (#50)

### DIFF
--- a/routes/auth.py
+++ b/routes/auth.py
@@ -62,6 +62,7 @@ def logout():
 
 
 @auth_bp.route('/novo_usuario', methods=['GET', 'POST'])
+@limiter.limit("10 per hour", methods=["POST"])
 def novo_usuario():
     mensagem = None
     if request.method == 'POST':
@@ -89,14 +90,17 @@ def novo_usuario():
                 return render_template('novo_usuario.html', mensagem="Email inválido."), 400
 
             with get_db_cursor() as cursor:
-                cursor.execute("SELECT id FROM usuarios WHERE username = %s", (novo_user,))
+                # Mensagem genérica (não revela QUAL campo colide) para não dar
+                # oráculo de enumeração de usuário/email — ver issue #50.
+                cursor.execute(
+                    "SELECT id FROM usuarios WHERE username = %s OR email = %s",
+                    (novo_user, email)
+                )
                 if cursor.fetchone():
-                    mensagem = f"Usuário '{novo_user}' já existe."
-                    return render_template('novo_usuario.html', mensagem=mensagem), 400
-
-                cursor.execute("SELECT id FROM usuarios WHERE email = %s", (email,))
-                if cursor.fetchone():
-                    return render_template('novo_usuario.html', mensagem="Este email já está cadastrado."), 400
+                    return render_template(
+                        'novo_usuario.html',
+                        mensagem="Não foi possível criar a conta com esse usuário ou email."
+                    ), 400
 
                 hash_s = generate_password_hash(nova_senha)
                 cursor.execute(

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -140,6 +140,28 @@ def test_verificar_codigo_retorna_429_apos_10_tentativas(app_com_limite, client)
     assert r.status_code == 429
 
 
+# ── Issue #50 — Enumeração de usuário/email no cadastro ──────────────────────
+
+def test_novo_usuario_retorna_429_apos_10_tentativas(app_com_limite, client):
+    for _ in range(10):
+        client.post('/novo_usuario', data={
+            'username': 'x', 'password': 'senha123', 'email': 'x@y.com'})
+    r = client.post('/novo_usuario', data={
+        'username': 'x', 'password': 'senha123', 'email': 'x@y.com'})
+    assert r.status_code == 429
+
+
+def test_novo_usuario_duplicado_mensagem_generica_nao_vaza_campo(client):
+    """testuser já existe (conftest). A resposta não pode revelar QUAL campo
+    colidiu — sem 'já existe' do username nem 'email já cadastrado'."""
+    r = client.post('/novo_usuario', data={
+        'username': 'testuser', 'password': 'senha123', 'email': 'novo@exemplo.com'})
+    assert r.status_code == 400
+    corpo = r.data.decode('utf-8')
+    assert 'já existe' not in corpo
+    assert 'já está cadastrado' not in corpo
+
+
 # ── Grupo C — S2: Mutating GET → POST ────────────────────────────────────────
 
 def test_excluir_animal_get_retorna_405(client):


### PR DESCRIPTION
## Problema
`novo_usuario` retornava mensagens distintas para "Usuário 'X' já existe." e "Este email já está cadastrado.", permitindo enumerar usuários e emails registrados. A rota também não tinha rate limit (ao contrário de `/login` e `/esqueci_senha`).

## Solução
- **Rate limit:** `@limiter.limit("10 per hour", methods=["POST"])` — throttla tentativas automatizadas de enumeração sem atrapalhar cadastro legítimo.
- **Mensagem genérica:** checagem de duplicidade unificada em uma query (`username = %s OR email = %s`), com resposta única "Não foi possível criar a conta com esse usuário ou email." — remove o oráculo de qual campo colidiu.

Alinha o cadastro ao cuidado que o fluxo de reset (`esqueci_senha`) já tinha.

## Testes
- `test_novo_usuario_retorna_429_apos_10_tentativas`
- `test_novo_usuario_duplicado_mensagem_generica_nao_vaza_campo`

Ambos passam localmente.

> Nota: resistência total à enumeração em cadastro exigiria fluxo de verificação por email (fora do escopo desta issue de severidade baixa). Estas mudanças fecham o oráculo de campo e limitam a taxa.

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)