### PR TITLE
test: ajusta testes de cadastro à mensagem genérica de duplicidade (#50)

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -146,7 +146,9 @@ def test_novo_usuario_username_duplicado_retorna_erro(client, mock_smtp):
         'username': username, 'password': 'outrasenha', 'email': 'outro@example.com',
     })
     assert response.status_code == 400
-    assert b'j\xc3\xa1 existe' in response.data
+    # Mensagem genérica (issue #50): não revela QUAL campo colidiu.
+    assert 'Não foi possível criar a conta'.encode('utf-8') in response.data
+    assert b'j\xc3\xa1 existe' not in response.data
     _purge_user(row[0])
 
 
@@ -163,7 +165,9 @@ def test_novo_usuario_email_duplicado_retorna_erro(client, mock_smtp):
         'username': username2, 'password': 'senha123', 'email': email,
     })
     assert response.status_code == 400
-    assert 'já está cadastrado'.encode('utf-8') in response.data
+    # Mensagem genérica (issue #50): não revela QUAL campo colidiu.
+    assert 'Não foi possível criar a conta'.encode('utf-8') in response.data
+    assert 'já está cadastrado'.encode('utf-8') not in response.data
     _purge_user(row[0])
 
 


### PR DESCRIPTION
## Contexto
Regressão de teste após o merge do #57 (issue #50). Ao trocar as mensagens específicas de duplicidade por uma genérica (anti-enumeração), dois testes pré-existentes em `test_auth.py` continuaram afirmando os textos antigos e passaram a falhar:

- `test_novo_usuario_username_duplicado_retorna_erro`
- `test_novo_usuario_email_duplicado_retorna_erro`

## Mudança
Test-only: as duas asserções passam a exigir a mensagem genérica "Não foi possível criar a conta…" e a garantir que os textos antigos ("já existe" / "já está cadastrado") **não** aparecem. O comportamento testado (duplicado → 400) permanece.

Suíte completa (excluindo e2e) volta a ficar verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)