### PR TITLE
feat: agrupa navbar em sub-navegação por abas

### DIFF
--- a/static/css/design_system.css
+++ b/static/css/design_system.css
@@ -221,6 +221,7 @@ h3 { font-size: var(--text-lg); font-weight: var(--weight-medium); }
   text-decoration: none;
   padding: var(--space-2) var(--space-3);
   border-radius: var(--radius-md);
+  white-space: nowrap;
   transition: color var(--transition-fast), background var(--transition-fast);
 }
 
@@ -281,6 +282,34 @@ h3 { font-size: var(--text-lg); font-weight: var(--weight-medium); }
 .nav-dropdown-item {
   display: block;
   white-space: nowrap;
+}
+
+/* ── Tab nav — sub-navegação dentro de uma página-mãe ───── */
+.tab-nav {
+  display: flex;
+  gap: var(--space-1);
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: var(--space-6);
+  overflow-x: auto;
+}
+
+.tab-nav-link {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-ink-secondary);
+  text-decoration: none;
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  white-space: nowrap;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.tab-nav-link:hover { color: var(--color-ink); }
+
+.tab-nav-link.active {
+  color: var(--color-primary);
+  border-bottom-color: var(--color-primary);
 }
 
 /* ── Layout ──────────────────────────────────────────────── */

--- a/templates/_macros.html
+++ b/templates/_macros.html
@@ -19,3 +19,14 @@
   {% endif %}
 </div>
 {% endmacro %}
+
+{# Sub-navegação por abas dentro de uma página-mãe.
+   tabs: lista de (label, href, ativo). Ativo definido pelo chamador via request.endpoint. #}
+{% macro tab_nav(tabs) %}
+<nav class="tab-nav" aria-label="Seções">
+  {% for label, href, ativo in tabs %}
+  <a href="{{ href }}" class="tab-nav-link{% if ativo %} active{% endif %}"
+     {% if ativo %}aria-current="page"{% endif %}>{{ label }}</a>
+  {% endfor %}
+</nav>
+{% endmacro %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -42,35 +42,23 @@
       </div>
     </div>
     <a href="{{ url_for('operacional.painel') }}"
-       class="nav-link{% if request.endpoint and request.endpoint.startswith('operacional') %} active{% endif %}">
+       class="nav-link{% if request.endpoint and request.endpoint.startswith('operacional') and request.endpoint != 'operacional.ranking_touros' %} active{% endif %}">
       Rebanho
-    </a>
-    <a href="{{ url_for('operacional.ranking_touros') }}"
-       class="nav-link{% if request.endpoint == 'operacional.ranking_touros' %} active{% endif %}">
-      Ranking de Touros
     </a>
     <a href="{{ url_for('financeiro.financeiro') }}"
        class="nav-link{% if request.endpoint and request.endpoint.startswith('financeiro') %} active{% endif %}">
       Financeiro
-    </a>
-    <a href="{{ url_for('financeiro.resultado_lotes') }}"
-       class="nav-link{% if request.endpoint in ('financeiro.resultado_lotes', 'financeiro.detalhe_lote') %} active{% endif %}">
-      Financeiro/Lotes
     </a>
     <a href="{{ url_for('pastos.listar_pastos') }}"
        class="nav-link{% if request.endpoint and request.endpoint.startswith('pastos') %} active{% endif %}">
       Pastos
     </a>
     <a href="{{ url_for('estoque.lista_estoque') }}"
-       class="nav-link{% if request.endpoint and request.endpoint.startswith('estoque') %} active{% endif %}">
-      Estoque
-    </a>
-    <a href="{{ url_for('sanitario.lista_protocolos') }}"
-       class="nav-link{% if request.endpoint and request.endpoint.startswith('sanitario') %} active{% endif %}">
-      Sanitário
+       class="nav-link{% if request.endpoint and (request.endpoint.startswith('estoque') or request.endpoint.startswith('sanitario')) %} active{% endif %}">
+      Manejo
     </a>
     <a href="{{ url_for('api.graficos_page') }}"
-       class="nav-link{% if request.endpoint == 'api.graficos_page' %} active{% endif %}">
+       class="nav-link{% if request.endpoint == 'api.graficos_page' or request.endpoint == 'operacional.ranking_touros' %} active{% endif %}">
       Relatórios
     </a>
     <a href="{{ url_for('configuracoes.settings') }}"

--- a/templates/detalhe_lote.html
+++ b/templates/detalhe_lote.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% import '_macros.html' as m %}
 {% block title %}Lote {{ lote[1] }}{% endblock %}
 
 {% block content %}
@@ -14,6 +15,11 @@
     <a href="{{ url_for('financeiro.resultado_lotes') }}" class="btn btn-secondary btn-sm">← Todos os lotes</a>
   </div>
 </div>
+
+{{ m.tab_nav([
+  ('Fluxo de caixa', url_for('financeiro.financeiro'), request.endpoint == 'financeiro.financeiro'),
+  ('Resultado por lote', url_for('financeiro.resultado_lotes'), request.endpoint in ('financeiro.resultado_lotes', 'financeiro.detalhe_lote')),
+]) }}
 
 <!-- ── KPIs do lote ───────────────────────────────────────── -->
 {% set pct_vendidos = ((lote[8] / lote[4]) * 100) | round(1) if lote[4] > 0 else 0 %}

--- a/templates/estoque_lista.html
+++ b/templates/estoque_lista.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% import '_macros.html' as m %}
 {% block title %}Estoque Virtual{% endblock %}
 
 {% block extra_css %}
@@ -26,6 +27,11 @@
   </div>
   <a href="{{ url_for('operacional.painel') }}" class="btn btn-ghost btn-sm">← Painel</a>
 </div>
+
+{{ m.tab_nav([
+  ('Estoque', url_for('estoque.lista_estoque'), request.endpoint and request.endpoint.startswith('estoque')),
+  ('Protocolos', url_for('sanitario.lista_protocolos'), request.endpoint and request.endpoint.startswith('sanitario')),
+]) }}
 
 
 <!-- ── Alerta de estoque baixo ─────────────────────── -->

--- a/templates/financeiro.html
+++ b/templates/financeiro.html
@@ -19,13 +19,17 @@
       <svg aria-hidden="true" class="icon icon-sm" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
       Contas a Pagar
     </a>
-    <a href="{{ url_for('financeiro.resultado_lotes') }}" class="btn btn-secondary btn-sm">P&L por Lote</a>
     <a href="{{ url_for('financeiro.simulador_custo') }}" class="btn btn-primary btn-sm">
       <svg aria-hidden="true" class="icon icon-sm" viewBox="0 0 24 24"><rect x="4" y="2" width="16" height="20" rx="2"/><line x1="8" y1="6" x2="16" y2="6"/><line x1="8" y1="10" x2="16" y2="10"/><line x1="8" y1="14" x2="11" y2="14"/><path d="m15 14 1.5 1.5L19 13M15 19l1.5 1.5L19 17"/></svg>
       Simulador
     </a>
   </div>
 </div>
+
+{{ m.tab_nav([
+  ('Fluxo de caixa', url_for('financeiro.financeiro'), request.endpoint == 'financeiro.financeiro'),
+  ('Resultado por lote', url_for('financeiro.resultado_lotes'), request.endpoint in ('financeiro.resultado_lotes', 'financeiro.detalhe_lote')),
+]) }}
 
 <!-- ── Métricas absolutas ─────────────────────────────── -->
 <div class="grid-metrics">

--- a/templates/graficos.html
+++ b/templates/graficos.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% import '_macros.html' as m %}
 {% block title %}Relatórios — Rebanho{% endblock %}
 
 {% block extra_css %}
@@ -26,6 +27,11 @@
     <a href="{{ url_for('operacional.painel') }}" class="btn btn-secondary btn-sm">← Painel</a>
   </div>
 </div>
+
+{{ m.tab_nav([
+  ('Gráficos', url_for('api.graficos_page'), request.endpoint == 'api.graficos_page'),
+  ('Ranking de Touros', url_for('operacional.ranking_touros'), request.endpoint == 'operacional.ranking_touros'),
+]) }}
 
 <!-- ── Card GMD ───────────────────────────────────────── -->
 <div class="grid-metrics" style="margin-bottom:var(--space-6);">

--- a/templates/ranking_touros.html
+++ b/templates/ranking_touros.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% import '_macros.html' as m %}
 {% block title %}Ranking de Touros{% endblock %}
 
 {% block content %}
@@ -10,6 +11,11 @@
   </div>
   <a href="{{ url_for('operacional.painel') }}" class="btn btn-ghost btn-sm">← Painel</a>
 </div>
+
+{{ m.tab_nav([
+  ('Gráficos', url_for('api.graficos_page'), request.endpoint == 'api.graficos_page'),
+  ('Ranking de Touros', url_for('operacional.ranking_touros'), request.endpoint == 'operacional.ranking_touros'),
+]) }}
 
 <!-- ── Card GMD do rebanho ────────────────────────────── -->
 <div class="grid-metrics" style="margin-bottom:var(--space-6);">

--- a/templates/resultado_lotes.html
+++ b/templates/resultado_lotes.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% import '_macros.html' as m %}
 {% block title %}P&L por Lote{% endblock %}
 
 {% block content %}
@@ -9,10 +10,14 @@
     <h1 class="page-title">Resultado por Lote</h1>
   </div>
   <div style="display:flex; gap:var(--space-2); flex-wrap:wrap; align-items:center;">
-    <a href="{{ url_for('financeiro.financeiro') }}" class="btn btn-secondary btn-sm">← Financeiro</a>
     <a href="{{ url_for('operacional.cadastro_lote') }}" class="btn btn-primary btn-sm">+ Novo Lote</a>
   </div>
 </div>
+
+{{ m.tab_nav([
+  ('Fluxo de caixa', url_for('financeiro.financeiro'), request.endpoint == 'financeiro.financeiro'),
+  ('Resultado por lote', url_for('financeiro.resultado_lotes'), request.endpoint in ('financeiro.resultado_lotes', 'financeiro.detalhe_lote')),
+]) }}
 
 {% if lotes %}
 

--- a/templates/sanitario_lista.html
+++ b/templates/sanitario_lista.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% import '_macros.html' as m %}
 {% block title %}Calendário Sanitário{% endblock %}
 
 {% block content %}
@@ -10,6 +11,11 @@
   </div>
   <a href="{{ url_for('operacional.painel') }}" class="btn btn-ghost btn-sm">← Painel</a>
 </div>
+
+{{ m.tab_nav([
+  ('Estoque', url_for('estoque.lista_estoque'), request.endpoint and request.endpoint.startswith('estoque')),
+  ('Protocolos', url_for('sanitario.lista_protocolos'), request.endpoint and request.endpoint.startswith('sanitario')),
+]) }}
 
 
 <!-- ── Formulário de cadastro ─────────────────────────── -->


### PR DESCRIPTION
Closes #60

## Problema
A navbar quebrava em larguras intermediárias (~769–1150px): os 9 links inline não cabiam, o texto quebrava dentro do link e a barra desalinhava. O colapso para hamburger só ocorria em `max-width:768px`, tarde demais para a quantidade de itens.

## Solução
Reduz o topo de **9 → 6 itens** consolidando destinos afins em sub-navegação por abas dentro da página-mãe. Mesma técnica de `active` via `request.endpoint` já usada na navbar — **sem JS, rota ou banco novos**.

Topo final: `Rebanho · Financeiro · Pastos · Manejo · Relatórios · Configurações`

| Grupo | Abas |
|---|---|
| Financeiro | Fluxo de caixa \| Resultado por lote |
| Relatórios | Gráficos \| Ranking de Touros |
| Manejo (Estoque + Sanitário) | Estoque \| Protocolos |

## Mudanças
- `_macros.html`: macro `tab_nav` (uma definição, 6 usos)
- `design_system.css`: componente `.tab-nav` + `white-space:nowrap` no `.nav-link` (rede de segurança)
- `base.html`: remove 3 links, funde Estoque+Sanitário em **Manejo**, estende `active` de Relatórios ao ranking
- 6 templates de página ganham a tira de abas; botões redundantes ("P&L por Lote", "← Financeiro") removidos

## Verificação
- Todos os templates compilam (Jinja parse/compile OK)
- Todos os endpoints referenciados existem
- ⚠️ Não validado visualmente no navegador (MySQL local indisponível na sessão)

🤖 Generated with [Claude Code](https://claude.com/claude-code)