### PR TITLE
Barra de ações no painel + painel "Mais ações" animado

### DIFF
--- a/static/css/design_system.css
+++ b/static/css/design_system.css
@@ -283,6 +283,75 @@ h3 { font-size: var(--text-lg); font-weight: var(--weight-medium); }
   white-space: nowrap;
 }
 
+/* ── Menu de ações animado (painel "Mais ações") ─────────────
+   Inspirado no popup checkbox do mockapi, adaptado aos tokens.
+   Usa opacity/visibility/transform (não display) para animar. */
+.action-menu {
+  position: relative;
+}
+
+.action-menu__panel {
+  position: absolute;
+  top: calc(100% + var(--space-1));
+  right: 0;
+  min-width: 200px;
+  padding: var(--space-1);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  z-index: var(--z-nav);
+  transform-origin: top right;
+  transform: scale(0.96);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--transition-fast),
+              transform var(--transition-fast),
+              visibility var(--transition-fast);
+}
+
+.action-menu__panel.open {
+  transform: scale(1);
+  opacity: 1;
+  visibility: visible;
+}
+
+.action-menu__item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-family: inherit;
+  font-size: var(--text-sm);
+  color: var(--color-ink);
+  text-align: left;
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: color var(--transition-fast), background var(--transition-fast);
+}
+
+.action-menu__item:hover,
+.action-menu__item:focus-visible {
+  background: var(--color-primary-bg);
+  color: var(--color-primary);
+  outline: none;
+}
+
+.action-menu__sep {
+  margin: var(--space-1) 0;
+  border: none;
+  border-top: 1px solid var(--color-border);
+}
+
+/* seta do gatilho gira ao abrir */
+.action-menu__trigger svg { transition: transform var(--transition-fast); }
+.action-menu__trigger[aria-expanded="true"] svg { transform: rotate(180deg); }
+
 /* ── Layout ──────────────────────────────────────────────── */
 .page-container {
   max-width: 1200px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,7 +13,7 @@
     <h1 class="page-title">Gestão do Rebanho</h1>
   </div>
   <div class="flex flex-wrap items-center gap-2">
-    <div id="mini-widget" class="mini-cotacao" style="display:none; margin-right:var(--space-3);">
+    <div id="mini-widget" class="mini-cotacao" style="display:none;">
       <span id="lbl-uf" style="text-transform:uppercase; font-weight:700; font-size:var(--text-xs); color:var(--color-ink-secondary);">--</span>
       <span style="color:var(--color-border-strong);">|</span>
       <span style="font-size:var(--text-xs);">Boi: <strong id="preco-boi">--</strong></span>
@@ -25,6 +25,11 @@
         Ver Brasil
       </button>
     </div>
+  </div>
+</div>
+
+<!-- ── Barra de ações ──────────────────────────────────── -->
+<div class="header-actions flex flex-wrap items-center gap-2" style="justify-content:flex-end; margin-bottom:var(--space-6);">
     <!-- Dropdown "Mais ações" — agrupa ações secundárias para reduzir densidade no mobile -->
     <div class="header-more-actions" style="position:relative;">
       <button type="button" class="btn btn-secondary btn-sm" id="btn-mais-acoes"
@@ -77,7 +82,6 @@
       <svg aria-hidden="true" class="icon icon-sm" viewBox="0 0 24 24"><path d="M17 1l4 4-4 4"/><path d="M3 11V9a4 4 0 0 1 4-4h14"/><path d="M7 23l-4-4 4-4"/><path d="M21 13v2a4 4 0 0 1-4 4H3"/></svg>
       Transações
     </a>
-  </div>
 </div>
 
 <!-- ── Cards de métrica ────────────────────────────────── -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,40 +31,28 @@
 <!-- ── Barra de ações ──────────────────────────────────── -->
 <div class="header-actions flex flex-wrap items-center gap-2" style="justify-content:flex-end; margin-bottom:var(--space-6);">
     <!-- Dropdown "Mais ações" — agrupa ações secundárias para reduzir densidade no mobile -->
-    <div class="header-more-actions" style="position:relative;">
-      <button type="button" class="btn btn-secondary btn-sm" id="btn-mais-acoes"
+    <div class="action-menu">
+      <button type="button" class="btn btn-secondary btn-sm action-menu__trigger" id="btn-mais-acoes"
               aria-haspopup="true" aria-expanded="false"
               onclick="toggleMaisAcoes(event)">
         Mais ações
         <svg aria-hidden="true" class="icon icon-sm" viewBox="0 0 24 24" style="margin-left:2px;"><polyline points="6 9 12 15 18 9"/></svg>
       </button>
-      <div id="menu-mais-acoes" role="menu" aria-labelledby="btn-mais-acoes"
-           style="display:none; position:absolute; top:calc(100% + 6px); right:0; z-index:200;
-                  background:var(--color-surface); border:1px solid var(--color-border);
-                  border-radius:var(--radius-md); box-shadow:var(--shadow-md);
-                  min-width:180px; padding:var(--space-1) 0;">
-        <button role="menuitem" onclick="gerarPDF(); fecharMaisAcoes();"
-                style="display:flex; align-items:center; gap:var(--space-2); width:100%; padding:var(--space-2) var(--space-3); background:none; border:none; cursor:pointer; font-size:var(--text-sm); color:var(--color-ink); text-align:left; white-space:nowrap;"
-                onmouseover="this.style.background='var(--color-bg)'" onmouseout="this.style.background='none'">
+      <div id="menu-mais-acoes" class="action-menu__panel" role="menu" aria-labelledby="btn-mais-acoes">
+        <button role="menuitem" class="action-menu__item" onclick="gerarPDF(); fecharMaisAcoes();">
           <svg aria-hidden="true" class="icon icon-sm" viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
           Relatório PDF
         </button>
-        <a role="menuitem" href="{{ url_for('api.export_animais_csv') }}"
-           style="display:flex; align-items:center; gap:var(--space-2); padding:var(--space-2) var(--space-3); font-size:var(--text-sm); color:var(--color-ink); text-decoration:none; white-space:nowrap;"
-           onmouseover="this.style.background='var(--color-bg)'" onmouseout="this.style.background='none'">
+        <a role="menuitem" class="action-menu__item" href="{{ url_for('api.export_animais_csv') }}">
           <svg aria-hidden="true" class="icon icon-sm" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           Exportar CSV
         </a>
-        <a role="menuitem" href="{{ url_for('operacional.importar_csv') }}"
-           style="display:flex; align-items:center; gap:var(--space-2); padding:var(--space-2) var(--space-3); font-size:var(--text-sm); color:var(--color-ink); text-decoration:none; white-space:nowrap;"
-           onmouseover="this.style.background='var(--color-bg)'" onmouseout="this.style.background='none'">
+        <a role="menuitem" class="action-menu__item" href="{{ url_for('operacional.importar_csv') }}">
           <svg aria-hidden="true" class="icon icon-sm" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/><line x1="12" y1="3" x2="12" y2="9"/><polyline points="17 5 12 0 7 5"/></svg>
           Importar CSV
         </a>
-        <hr style="margin:var(--space-1) 0; border:none; border-top:1px solid var(--color-border);">
-        <a role="menuitem" href="{{ url_for('operacional.ranking_touros') }}"
-           style="display:flex; align-items:center; gap:var(--space-2); padding:var(--space-2) var(--space-3); font-size:var(--text-sm); color:var(--color-ink); text-decoration:none; white-space:nowrap;"
-           onmouseover="this.style.background='var(--color-bg)'" onmouseout="this.style.background='none'">
+        <hr class="action-menu__sep">
+        <a role="menuitem" class="action-menu__item" href="{{ url_for('operacional.ranking_touros') }}">
           <svg aria-hidden="true" class="icon icon-sm" viewBox="0 0 24 24"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
           Ranking Touros
         </a>
@@ -611,13 +599,13 @@ function toggleMaisAcoes(e) {
   e.stopPropagation();
   var menu = document.getElementById('menu-mais-acoes');
   var btn  = document.getElementById('btn-mais-acoes');
-  var open = menu.style.display === 'none';
-  menu.style.display = open ? 'block' : 'none';
+  var open = !menu.classList.contains('open');
+  menu.classList.toggle('open', open);
   btn.setAttribute('aria-expanded', open ? 'true' : 'false');
 }
 function fecharMaisAcoes() {
   var menu = document.getElementById('menu-mais-acoes');
-  if (menu) { menu.style.display = 'none'; }
+  if (menu) { menu.classList.remove('open'); }
   var btn = document.getElementById('btn-mais-acoes');
   if (btn) btn.setAttribute('aria-expanded', 'false');
 }


### PR DESCRIPTION
Closes #62

## Problema
No painel, em larguras intermediárias (~1024px) o cabeçalho quebrava em 2 linhas: cotação e os 4 botões de ação disputavam o mesmo cluster `flex-wrap` do `.page-header`.

## Mudanças
- **Barra de ações própria** (`.header-actions`): cabeçalho mantém só a cotação (`#mini-widget`); dropdown + `Vacina`/`Pesagem`/`Transações` vão para uma linha própria abaixo. Ações e cotação nunca mais colidem; no mobile os botões quebram entre si sem afetar o título.
- **Painel "Mais ações" animado** (`.action-menu` no `design_system.css`): abertura com scale+fade (opacity/visibility/transform, não `display`), hover verde nos itens e chevron que gira ao abrir. Remove estilo inline e handlers `onmouseover`; JS passa a togar a classe `.open`, preservando `aria-expanded`, Escape e click-fora.

## Verificação
Layout renderizado com o `design_system.css` real via Playwright em 1280/1024/900/390px — o cluster não quebra mais em nenhuma largura; menu abre alinhado, com hover e rotação do chevron corretos. Sem CSS/dependência supérfluos (reaproveita `flex flex-wrap gap-2` e os tokens existentes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)