### PR TITLE
Animação perceptível do painel Mais ações

### DIFF
--- a/static/css/design_system.css
+++ b/static/css/design_system.css
@@ -303,18 +303,22 @@ h3 { font-size: var(--text-lg); font-weight: var(--weight-medium); }
   box-shadow: var(--shadow-md);
   z-index: var(--z-nav);
   transform-origin: top right;
-  transform: scale(0.96);
+  transform: translateY(-8px) scale(0.94);
   opacity: 0;
   visibility: hidden;
-  transition: opacity var(--transition-fast),
-              transform var(--transition-fast),
-              visibility var(--transition-fast);
+  transition: opacity 220ms cubic-bezier(0.4, 0, 0.2, 1),
+              transform 220ms cubic-bezier(0.4, 0, 0.2, 1),
+              visibility 220ms;
 }
 
 .action-menu__panel.open {
-  transform: scale(1);
+  transform: translateY(0) scale(1);
   opacity: 1;
   visibility: visible;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .action-menu__panel { transition: none; }
 }
 
 .action-menu__item {


### PR DESCRIPTION
Closes 64

Torna a abertura do painel "Mais ações" visivelmente fluida: `translateY(-8px)` + `scale(0.94)` + fade em 220ms com ease suave (antes era `scale(0.96)` em 120ms, imperceptível). Respeita `prefers-reduced-motion`.

Tab-nav (indicador ativo deslizante + hover animado) vem em PR separado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)