### PR TITLE
fix: exibe cotação no mobile — #66

### DIFF
--- a/static/css/design_system.css
+++ b/static/css/design_system.css
@@ -999,7 +999,7 @@ tbody td {
 .mini-cotacao strong { font-weight: var(--weight-semibold); }
 
 @media (max-width: 768px) {
-  #mini-widget { display: none !important; }
+  .mini-cotacao { flex-wrap: wrap; white-space: normal; gap: var(--space-2); }
   .modal-content { padding: var(--space-5) var(--space-4); }
   .tabela-cotacao { font-size: var(--text-xs); }
   .tabela-cotacao th,


### PR DESCRIPTION
## Problema
O mini-widget de cotação (boi/novilha) sumia em telas ≤768px.

## Causa raiz
`static/css/design_system.css` tinha `@media (max-width: 768px) { #mini-widget { display: none !important; } }`, que ocultava o widget no mobile com `!important`, sobrescrevendo o `style.display = 'inline-flex'` aplicado via JS em `carregarCotacao()`. O dado carregava normal; o CSS escondia.

## Fix
Remove a regra de ocultação e deixa o widget quebrar linha no mobile (`flex-wrap: wrap` + `white-space: normal`) em vez de forçar `nowrap`, evitando estourar o cabeçalho.

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)