### PR TITLE
fix: valida animal_ids por user_id em iniciar_ocupacao

### DIFF
--- a/repositories/pasto_repository.py
+++ b/repositories/pasto_repository.py
@@ -106,17 +106,45 @@ def get_ocupacao_ativa(modulo_id, user_id):
 
 
 def iniciar_ocupacao(modulo_id, user_id, data_entrada, animal_ids):
-    """Insere ocupacao e ocupacao_animais em uma única transação. Retorna ocupacao_id."""
+    """Insere ocupacao e ocupacao_animais em uma única transação.
+
+    Valida que todos os animal_ids pertencem ao user_id antes de inserir —
+    mesmo padrão de animal_repository.registrar_pesagens_lote.
+    Retorna ocupacao_id.
+
+    IDs de outro tenant são descartados em silêncio: o form só lista os animais
+    do próprio usuário, então isso só ocorre em POST forjado.
+    """
+    ids = []
+    for aid in animal_ids:
+        try:
+            ids.append(int(aid))
+        except (TypeError, ValueError):
+            continue
+
     with get_db_cursor() as cursor:
         cursor.execute(
             "INSERT INTO ocupacoes (modulo_id, user_id, data_entrada) VALUES (%s, %s, %s)",
             (modulo_id, user_id, data_entrada)
         )
         ocupacao_id = cursor.lastrowid
-        cursor.executemany(
-            "INSERT INTO ocupacao_animais (ocupacao_id, animal_id) VALUES (%s, %s)",
-            [(ocupacao_id, int(aid)) for aid in animal_ids]
-        )
+
+        validos = set()
+        if ids:
+            placeholders = ','.join(['%s'] * len(ids))
+            cursor.execute(
+                f"SELECT id FROM animais WHERE id IN ({placeholders}) "
+                f"AND user_id = %s AND deleted_at IS NULL",
+                ids + [user_id]
+            )
+            validos = {row[0] for row in cursor.fetchall()}
+
+        if validos:
+            cursor.executemany(
+                "INSERT INTO ocupacao_animais (ocupacao_id, animal_id) VALUES (%s, %s)",
+                [(ocupacao_id, aid) for aid in validos]
+            )
+
         return ocupacao_id
 
 

--- a/tests/test_pastos.py
+++ b/tests/test_pastos.py
@@ -156,6 +156,25 @@ def test_iniciar_ocupacao_cria_registros(um):
     assert row[0] == 1
 
 
+def test_iniciar_ocupacao_ignora_animal_de_outro_tenant(dois):
+    """animal_ids forjados de outro usuário não podem entrar em ocupacao_animais."""
+    uid_a, uid_b = dois
+    aid_a = _make_animal(uid_a)
+    aid_b = _make_animal(uid_b)
+    pid = pasto_repository.insert_pasto(uid_a, "Pasto Vaz", None, None, 10.0)
+    mid = pasto_repository.insert_modulo(pid, uid_a, "Mod Vaz", None, 10.0)
+
+    oc_id = pasto_repository.iniciar_ocupacao(mid, uid_a, "2024-03-01", [aid_a, aid_b])
+
+    total = _fetch_one("SELECT COUNT(*) FROM ocupacao_animais WHERE ocupacao_id = %s", (oc_id,))[0]
+    alheio = _fetch_one(
+        "SELECT COUNT(*) FROM ocupacao_animais WHERE ocupacao_id = %s AND animal_id = %s",
+        (oc_id, aid_b),
+    )[0]
+    assert alheio == 0
+    assert total == 1
+
+
 def test_encerrar_ocupacao_libera_modulo(um):
     aid = _make_animal(um)
     pid = pasto_repository.insert_pasto(um, "Pasto Enc", None, None, 10.0)


### PR DESCRIPTION
Closes #75

## Causa raiz
`pasto_repository.iniciar_ocupacao` inseria em `ocupacao_animais` os `animal_ids` vindos do form **sem verificar o dono**. Todos os outros fluxos de lote (pesagem, venda, medicação) filtram por `user_id` — esta era a exceção.

Um POST forjado vinculava animal de outro tenant à ocupação do atacante. Como `vw_gmd_por_modulo` faz `JOIN ocupacao_animais -> pesagens`, o GMD do animal alheio passava a aparecer agregado no módulo — vazamento de dado zootécnico entre fazendas.

## Correção
Filtro por `user_id` **dentro do repository**, não na rota: é onde todos os callers passam. Mesmo padrão de `animal_repository.registrar_pesagens_lote`.

Bônus: `int(aid)` não estoura mais 500 com input não-numérico.

## Decisão de escopo
IDs alheios são descartados **em silêncio**, sem flash de aviso. Cheguei a implementar o retorno `(ocupacao_id, invalidos)` e desfiz: quebrava 11 call sites nos testes para reportar uma condição que só ocorre em POST forjado — o form nunca lista animal de outro tenant.

## Teste
`test_iniciar_ocupacao_ignora_animal_de_outro_tenant` em `tests/test_pastos.py` (arquivo que já tem as fixtures `dois`/`_make_animal`; `test_tenant_isolation.py` não tem fixture de pasto/módulo).

Verificado que falha sem o fix e passa com ele. Suíte completa: 312 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)