### PR TITLE
refactor: renderiza alerta de erro uma vez só, no base.html

### DIFF
--- a/templates/agendamentos.html
+++ b/templates/agendamentos.html
@@ -13,13 +13,6 @@
   <a href="{{ url_for('financeiro.financeiro') }}" class="btn btn-ghost btn-sm">← Financeiro</a>
 </div>
 
-{% if mensagem %}
-  <div class="alert alert-danger" role="alert" style="margin-bottom:var(--space-5);">
-    <span class="alert-icon" aria-hidden="true"><svg class="icon icon-md" viewBox="0 0 24 24"><path d="m10.29 3.86-8.6 14.9A2 2 0 0 0 3.43 22h17.14a2 2 0 0 0 1.74-2.84l-8.6-14.9a2 2 0 0 0-3.42 0Z"/><line x1="12" x2="12" y1="9" y2="13"/><line x1="12" x2="12.01" y1="17" y2="17"/></svg></span>
-    <div>{{ mensagem }}</div>
-  </div>
-{% endif %}
-
 <!-- ── Formulário de novo / editar agendamento ─────────── -->
 <div style="max-width:580px; margin-bottom:var(--space-8);">
   {% if editando %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -99,6 +99,15 @@
       </div>
     {% endfor %}
   {% endwith %}
+  {# `mensagem` é o canal de erro de validação: a rota devolve 400 + render (em vez de
+     redirect + flash) para não perder o form_data digitado. Renderizado aqui uma vez
+     só — as páginas não repetem esse bloco. #}
+  {% if mensagem %}
+    <div class="alert alert-danger" role="alert" style="margin-bottom:var(--space-5);">
+      <span class="alert-icon" aria-hidden="true"><svg class="icon icon-md" viewBox="0 0 24 24"><path d="m10.29 3.86-8.6 14.9A2 2 0 0 0 3.43 22h17.14a2 2 0 0 0 1.74-2.84l-8.6-14.9a2 2 0 0 0-3.42 0Z"/><line x1="12" x2="12" y1="9" y2="13"/><line x1="12" x2="12.01" y1="17" y2="17"/></svg></span>
+      <div>{{ mensagem }}</div>
+    </div>
+  {% endif %}
   {% block content %}{% endblock %}
 </main>
 

--- a/templates/cadastro.html
+++ b/templates/cadastro.html
@@ -11,19 +11,6 @@
   <a href="{{ url_for('operacional.painel') }}" class="btn btn-ghost btn-sm">← Voltar</a>
 </div>
 
-{% if mensagem_ok %}
-  <div class="alert alert-success" style="margin-bottom:var(--space-6);">
-    <span class="alert-icon" aria-hidden="true"><svg class="icon icon-md" aria-hidden="true" viewBox="0 0 24 24"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg></span>
-    <div>{{ mensagem_ok }}</div>
-  </div>
-{% endif %}
-{% if mensagem %}
-  <div class="alert alert-danger" style="margin-bottom:var(--space-6);">
-    <span class="alert-icon" aria-hidden="true"><svg class="icon icon-md" aria-hidden="true" viewBox="0 0 24 24"><path d="m10.29 3.86-8.6 14.9A2 2 0 0 0 3.43 22h17.14a2 2 0 0 0 1.74-2.84l-8.6-14.9a2 2 0 0 0-3.42 0Z"/><line x1="12" x2="12" y1="9" y2="13"/><line x1="12" x2="12.01" y1="17" y2="17"/></svg></span>
-    <div>{{ mensagem }}</div>
-  </div>
-{% endif %}
-
 <div style="max-width:520px;">
   <form action="{{ url_for('operacional.cadastro') }}" method="POST" class="form-container">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">

--- a/templates/cadastro_lote.html
+++ b/templates/cadastro_lote.html
@@ -8,18 +8,6 @@
 {% block content %}
     <h1>Entrada de Lote (Detalhada)</h1>
 
-    {% if mensagem %}
-        {% if 'Erro' in mensagem or '❌' in mensagem %}
-            <div class="alert" style="background-color: #FDDCDA; color: var(--danger-color); border: 1px solid #F1A9A6;">
-                {{ mensagem }}
-            </div>
-        {% else %}
-            <div class="alert" style="background-color: #D6E8D0; color: var(--primary-color); border: 1px solid #B8D4B2;">
-                {{ mensagem }}
-            </div>
-        {% endif %}
-    {% endif %}
-
     <form action="{{ url_for('operacional.cadastro_lote') }}" method="POST" class="form-container" style="max-width: 900px;">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 

--- a/templates/configuracoes.html
+++ b/templates/configuracoes.html
@@ -13,13 +13,6 @@
 
     <div class="form-container" style="max-width: 600px; margin: 0 auto; background: white; padding: 20px; border-radius: 8px;">
 
-        {% if mensagem %}
-        <div class="alert alert-danger" role="alert" style="margin-bottom:var(--space-4);">
-          <span class="alert-icon" aria-hidden="true"><svg class="icon icon-md" viewBox="0 0 24 24"><path d="m10.29 3.86-8.6 14.9A2 2 0 0 0 3.43 22h17.14a2 2 0 0 0 1.74-2.84l-8.6-14.9a2 2 0 0 0-3.42 0Z"/><line x1="12" x2="12" y1="9" y2="13"/><line x1="12" x2="12.01" y1="17" y2="17"/></svg></span>
-          <div>{{ mensagem }}</div>
-        </div>
-        {% endif %}
-
         <form method="POST" action="{{ url_for('configuracoes.settings') }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <div class="form-group">

--- a/templates/custos_operacionais.html
+++ b/templates/custos_operacionais.html
@@ -11,13 +11,6 @@
   <a href="{{ url_for('financeiro.financeiro') }}" class="btn btn-ghost btn-sm">← Financeiro</a>
 </div>
 
-{% if mensagem %}
-  <div class="alert alert-danger" role="alert" style="margin-bottom:var(--space-6);">
-    <span class="alert-icon" aria-hidden="true"><svg class="icon icon-md" viewBox="0 0 24 24"><path d="m10.29 3.86-8.6 14.9A2 2 0 0 0 3.43 22h17.14a2 2 0 0 0 1.74-2.84l-8.6-14.9a2 2 0 0 0-3.42 0Z"/><line x1="12" x2="12" y1="9" y2="13"/><line x1="12" x2="12.01" y1="17" y2="17"/></svg></span>
-    <div>{{ mensagem }}</div>
-  </div>
-{% endif %}
-
 <div style="max-width:480px;">
   <form action="{{ url_for('financeiro.custos_operacionais') }}" method="POST" class="form-container">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">

--- a/templates/medicar.html
+++ b/templates/medicar.html
@@ -12,13 +12,6 @@
      class="btn btn-ghost btn-sm">← Voltar à ficha</a>
 </div>
 
-{% if mensagem %}
-  <div class="alert alert-danger" style="margin-bottom:var(--space-6);">
-    <span class="alert-icon" aria-hidden="true"><svg class="icon icon-md" aria-hidden="true" viewBox="0 0 24 24"><path d="m10.29 3.86-8.6 14.9A2 2 0 0 0 3.43 22h17.14a2 2 0 0 0 1.74-2.84l-8.6-14.9a2 2 0 0 0-3.42 0Z"/><line x1="12" x2="12" y1="9" y2="13"/><line x1="12" x2="12.01" y1="17" y2="17"/></svg></span>
-    <div>{{ mensagem }}</div>
-  </div>
-{% endif %}
-
 <div style="max-width:480px;">
   <form action="{{ url_for('operacional.medicar', id_animal=id_animal) }}"
         method="POST" class="form-container">

--- a/templates/nova_pesagem.html
+++ b/templates/nova_pesagem.html
@@ -12,13 +12,6 @@
      class="btn btn-ghost btn-sm">← Voltar à ficha</a>
 </div>
 
-{% if mensagem %}
-  <div class="alert alert-danger" style="margin-bottom:var(--space-6);">
-    <span class="alert-icon" aria-hidden="true"><svg class="icon icon-md" aria-hidden="true" viewBox="0 0 24 24"><path d="m10.29 3.86-8.6 14.9A2 2 0 0 0 3.43 22h17.14a2 2 0 0 0 1.74-2.84l-8.6-14.9a2 2 0 0 0-3.42 0Z"/><line x1="12" x2="12" y1="9" y2="13"/><line x1="12" x2="12.01" y1="17" y2="17"/></svg></span>
-    <div>{{ mensagem }}</div>
-  </div>
-{% endif %}
-
 <div style="max-width:400px;">
   <form action="{{ url_for('operacional.nova_pesagem', id_animal=id_animal) }}"
         method="POST" class="form-container">

--- a/templates/vender.html
+++ b/templates/vender.html
@@ -20,13 +20,6 @@
   </div>
 </div>
 
-{% if mensagem %}
-  <div class="alert alert-danger" style="margin-bottom:var(--space-6);">
-    <span class="alert-icon" aria-hidden="true"><svg class="icon icon-md" aria-hidden="true" viewBox="0 0 24 24"><path d="m10.29 3.86-8.6 14.9A2 2 0 0 0 3.43 22h17.14a2 2 0 0 0 1.74-2.84l-8.6-14.9a2 2 0 0 0-3.42 0Z"/><line x1="12" x2="12" y1="9" y2="13"/><line x1="12" x2="12.01" y1="17" y2="17"/></svg></span>
-    <div>{{ mensagem }}</div>
-  </div>
-{% endif %}
-
 <div style="max-width:480px;">
   <form action="{{ url_for('operacional.vender', id_animal=id_animal) }}"
         method="POST" class="form-container">

--- a/tests/test_financeiro.py
+++ b/tests/test_financeiro.py
@@ -420,3 +420,27 @@ def test_agendamentos_baixar_de_outro_usuario_nao_altera(client):
     row = cur.fetchone()
     cur.close(); conn.close()
     assert row[0] == 'pendente'
+
+
+# ── Alerta de erro centralizado no base.html (issue #72) ─────────────────────
+
+def test_erro_de_validacao_renderiza_alerta(client):
+    """`mensagem` é renderizada pelo base.html — os templates não repetem mais o bloco.
+
+    Guarda a issue #72: se a renderização central sumir, o usuário perde o
+    feedback de validação sem que nenhum status HTTP mude.
+    """
+    login(client)
+    response = client.post('/custos_operacionais', data={
+        'categoria': 'Variavel',
+        'tipo_variavel': 'Nutrição',
+        'valor': '-5',            # viola min_val=0.01
+        'data': '2024-01-01',
+        'descricao': '',
+    })
+    assert response.status_code == 200
+    corpo = response.data.decode('utf-8')
+    assert 'alert-danger' in corpo
+    assert 'Valor' in corpo
+    # e o form_data digitado sobrevive ao erro (motivo de não usar redirect+flash)
+    assert 'Nutri' in corpo


### PR DESCRIPTION
Closes #72

**Reabertura da PR #74**, que mergeou na base errada. A #74 apontava para `refactor/navegacao-principal` e mergeou 13 segundos *depois* da #73 ter ido para `main` — ou seja, numa branch já morta. O commit `e4d0646` nunca chegou em `main`:

```
git merge-base --is-ancestor e4d0646 origin/main  →  NO
```

Mesmo código, agora com base em `main`.

## Mudança
O markup `.alert.alert-danger` + SVG estava copiado em 8 templates que estendem `base.html`, enquanto o próprio `base.html` já renderizava `flash()` com esse mesmo markup. Sucesso e erro chegavam por dois caminhos, com duas cópias do componente.

`mensagem` passa a ser renderizada centralmente em `base.html`, ao lado do bloco de flash; as 8 cópias saem. `cadastro_lote.html` para de farejar string (`{% if 'Erro' in mensagem %}`).

Templates de auth ficam de fora — não estendem `base.html` e usam `.flash` de `auth.css`, shell separado. Deliberado.

+33/−67 em 10 arquivos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)