### PR TITLE
fix: não semeia mais o usuário admin com senha fixa

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -9,6 +9,12 @@ DB_POOL_SIZE=   # tamanho do pool de conexões, default 5
 # Segurança
 SECRET_KEY=     # chave secreta Flask — gere com: python -c "import secrets; print(secrets.token_hex(32))"
 
+# Bootstrap do usuário 'admin' — SOMENTE em ambiente local.
+# Deixe SEED_ADMIN vazio em produção: init_db.py roda a cada deploy e criaria
+# uma conta de acesso com senha conhecida. Sem estas vars, só o schema é criado.
+SEED_ADMIN=     # 'true' para criar o usuário 'admin' no primeiro init_db.py
+ADMIN_PASSWORD= # senha do usuário 'admin' (obrigatória se SEED_ADMIN=true)
+
 # Email (SMTP) — necessário para recuperação de senha
 # Gmail: ative a verificação em 2 etapas e gere uma "Senha de App" em myaccount.google.com/apppasswords
 MAIL_SERVER=    # ex: smtp.gmail.com

--- a/init_db.py
+++ b/init_db.py
@@ -3,6 +3,7 @@ import os
 import sys
 import time
 from dotenv import load_dotenv
+from werkzeug.security import generate_password_hash
 
 load_dotenv()
 
@@ -48,17 +49,25 @@ def criar_schema(cursor):
     );
     """)
 
-    # 1.2 Inserção do ADMIN Padrão
-    print(" Verificando usuário 'admin'...")
-    hash_admin = 'scrypt:32768:8:1$kXp5C5q9Zz8s$6e28d45f348043653131707572706854199c07172551061919864273347072557766858172970635489708764835940561570198038755030800008853755355'
-    try:
-        cursor.execute("INSERT INTO usuarios (username, password_hash) VALUES (%s, %s)", ('admin', hash_admin))
-        print("   -> Usuário 'admin' criado (Senha: admin123).")
-    except mysql.connector.Error as err:
-        if err.errno == 1062:
-            print("   -> Usuário 'admin' já existe.")
-        else:
-            raise err
+    # 1.2 Inserção do ADMIN Padrão (opt-in, só para bootstrap de ambiente local)
+    # railway.toml roda este script a cada deploy: semear uma credencial fixa aqui
+    # criaria uma conta de acesso conhecida em produção. Exige SEED_ADMIN=true.
+    if os.getenv('SEED_ADMIN') == 'true':
+        senha_admin = os.getenv('ADMIN_PASSWORD')
+        if not senha_admin:
+            raise RuntimeError("SEED_ADMIN=true exige ADMIN_PASSWORD definido no ambiente.")
+        print(" Verificando usuário 'admin'...")
+        try:
+            cursor.execute(
+                "INSERT INTO usuarios (username, password_hash) VALUES (%s, %s)",
+                ('admin', generate_password_hash(senha_admin))
+            )
+            print("   -> Usuário 'admin' criado com a senha de ADMIN_PASSWORD.")
+        except mysql.connector.Error as err:
+            if err.errno == 1062:
+                print("   -> Usuário 'admin' já existe.")
+            else:
+                raise err
 
     # 1.3 Tabela ANIMAIS
     print(" [2/6] Criando tabela 'animais'...")


### PR DESCRIPTION
Closes #77

## Causa raiz
`init_db.py:53-61` inseria `admin` com um hash **hardcoded no fonte** (senha `admin123`, confirmada pelo próprio `print`). `railway.toml` roda `preDeployCommand = "python -u init_db.py"` a cada deploy → a conta é recriada em produção sempre. `routes/auth.py:38-49` autentica `admin` como um tenant normal.

## Correção
A criação passa a exigir `SEED_ADMIN=true` + `ADMIN_PASSWORD`, com o hash gerado em runtime via `generate_password_hash`. Sem as vars, `init_db.py` só cria schema — o comportamento correto em produção. `SEED_ADMIN=true` sem `ADMIN_PASSWORD` levanta `RuntimeError` em vez de cair num default silencioso.

Nada no código nem nos testes dependia do usuário `admin` (grep confirma: as únicas ocorrências eram as próprias linhas do seed).

## Verificação
Três caminhos testados contra um banco descartável:

| Cenário | Resultado |
|---|---|
| Sem `SEED_ADMIN` | 0 usuários `admin` ✅ |
| `SEED_ADMIN=true` sem senha | `RuntimeError` ✅ |
| Ambas as vars | admin criado com a senha da env; `admin123` **não** autentica ✅ |

Suíte completa: 311 passed.

## ⚠️ Ação manual necessária em produção
Este PR impede **novas** semeaduras — não remove a conta que já existe no banco de produção. Depois do merge, apagar ou rotacionar o `admin` atual manualmente:

```sql
DELETE FROM usuarios WHERE username = 'admin';
```

(Conferir antes se há dados de animais vinculados a esse `user_id`.)

## Fora de escopo
Troca forçada de senha no primeiro login — desnecessária se a conta não é criada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)