### PR TITLE
fix: instala o Chromium do Playwright no build de produção

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM python:3.10-slim
 WORKDIR /app
 
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt \
+    && playwright install --with-deps chromium
 
 COPY . .
 

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,10 @@
+# Railway usa o builder nixpacks (ver railway.toml) e ignora o Dockerfile.
+# O pacote pip do playwright NÃO traz o binário do Chromium; sem este passo a
+# geração de PDF (routes/api.py::_gerar_pdf_bg) falha em runtime gravando .error.
+#
+# Fase própria, dependente de 'install', para não sobrescrever a criação de venv
+# que o provider Python do nixpacks faz na fase install. 'python -m playwright'
+# em vez do script 'playwright' evita depender do bin do venv estar no PATH.
+[phases.playwright]
+dependsOn = ["install"]
+cmds = ["python -m playwright install --with-deps chromium"]


### PR DESCRIPTION
Closes #76

## Causa raiz
O pacote pip `playwright==1.60.0` não inclui o binário do Chromium — exige `playwright install chromium`. `railway.toml` usa `builder = "nixpacks"`, que **ignora o Dockerfile**, e nenhum caminho de build versionado rodava esse passo. Em runtime, `_gerar_pdf_bg` (`routes/api.py:118`) chama `chromium.launch()`, falha, e grava `.error` — falha silenciosa, sem alarme.

## Correção
- **`nixpacks.toml`** (novo) — o caminho que o Railway de fato usa. Fase `playwright` dependente de `install`, para não sobrescrever a criação de venv do provider Python do nixpacks. Uso `python -m playwright` em vez do script `playwright` para não depender do bin do venv estar no PATH.
- **`Dockerfile`** — mesmo passo após o `pip install`, para os dois caminhos convergirem (defesa caso o builder mude).

## O que NÃO precisou mudar
O ponto 3 do diagnóstico original (adicionar `logger.exception`) **já estava feito**: `routes/api.py:135` já registra `logger.error(..., exc_info=True)`. Não dupliquei.

## Verificação
- `nixpacks.toml` parseia (`tomllib`).
- `python -m playwright install chromium` retorna 0 localmente.
- O CI (#84) já instala o Chromium e a suíte e2e exercita `chromium.launch()` com sucesso — ou seja, a invocação do Playwright em si está provada verde. O que este PR conserta é o **build de produção**, que só se verifica no deploy do Railway.

## Limite honesto
Não tenho acesso ao Railway para confirmar o build lá. A correção segue o padrão documentado de nixpacks + playwright e está sintaticamente validada; a prova final é o próximo deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)