### PR TITLE
fix: usa UTC consistente no fluxo de reset de senha

### DIFF
--- a/repositories/auth_repository.py
+++ b/repositories/auth_repository.py
@@ -39,7 +39,9 @@ def get_valid_token(email, code):
             WHERE u.email = %s
               AND t.code = %s
               AND t.used = 0
-              AND t.expires_at > NOW()
+              -- expires_at é gravado em UTC (datetime.now(timezone.utc) em auth.py);
+              -- NOW() usa o fuso da sessão do servidor e deslocaria a janela — ver #59.
+              AND t.expires_at > UTC_TIMESTAMP()
         """, (email, code))
         return cursor.fetchone()
 

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -1,6 +1,6 @@
 import secrets
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from flask import Blueprint, render_template, request, redirect, url_for, flash, session
 from flask_login import login_user, login_required, logout_user, current_user
@@ -146,7 +146,7 @@ def esqueci_senha():
 
             if user:
                 code = str(secrets.randbelow(900000) + 100000)
-                expires_at = datetime.utcnow() + timedelta(minutes=15)
+                expires_at = datetime.now(timezone.utc) + timedelta(minutes=15)
                 auth_repository.save_reset_token(user[0], code, expires_at)
 
                 try:
@@ -177,7 +177,7 @@ def verificar_codigo():
         return redirect(url_for('auth.esqueci_senha'))
 
     expires_ts = session.get('reset_expires_at', 0)
-    expires_in_seconds = max(0, int(expires_ts - datetime.utcnow().timestamp()))
+    expires_in_seconds = max(0, int(expires_ts - datetime.now(timezone.utc).timestamp()))
     email_mascarado = _mascara_email(email)
 
     if request.method == 'POST':
@@ -221,7 +221,7 @@ def reenviar_codigo():
         user = auth_repository.get_user_by_email(email)
         if user:
             code = str(secrets.randbelow(900000) + 100000)
-            expires_at = datetime.utcnow() + timedelta(minutes=15)
+            expires_at = datetime.now(timezone.utc) + timedelta(minutes=15)
             auth_repository.save_reset_token(user[0], code, expires_at)
             try:
                 send_reset_code(email, code)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -228,6 +228,32 @@ def test_fluxo_completo_reset_de_senha(client, mock_smtp):
     _purge_user(uid)
 
 
+def test_get_valid_token_usa_utc_nao_fuso_do_servidor(client):
+    """Token expirado em UTC deve ser rejeitado mesmo com o servidor em fuso != UTC.
+
+    Regressão do #59: com NOW() (fuso da sessão do servidor; o CI roda em UTC-3),
+    um token expirado há minutos em UTC ainda passaria, pois NOW() local < expires_at
+    gravado em UTC. UTC_TIMESTAMP() casa com o valor gravado e corrige a janela.
+    """
+    from datetime import datetime, timezone, timedelta
+    from repositories import auth_repository
+
+    email = f"utc_{_n()}@example.com"
+    uid, _ = _make_user_with_email(email)
+    try:
+        auth_repository.save_reset_token(
+            uid, "111111", datetime.now(timezone.utc) - timedelta(minutes=1))
+        assert auth_repository.get_valid_token(email, "111111") is None, \
+            "token expirado em UTC não pode ser aceito"
+
+        auth_repository.save_reset_token(
+            uid, "222222", datetime.now(timezone.utc) + timedelta(minutes=15))
+        assert auth_repository.get_valid_token(email, "222222") is not None, \
+            "token válido (expira em 15 min UTC) deve ser aceito"
+    finally:
+        _purge_user(uid)
+
+
 def test_verificar_codigo_invalido_mostra_erro(client, mock_smtp):
     email = f"codigoerrado_{_n()}@example.com"
     uid, _ = _make_user_with_email(email)


### PR DESCRIPTION
Closes #59

## Causa raiz
`datetime.utcnow()` é depreciado e retorna um datetime **naive**. Três usos em `routes/auth.py` (`:149`, `:180`, `:224`), mais `NOW()` em `auth_repository.get_valid_token`.

## Por que não é um sed mecânico
Os dois lados naive erram na **mesma** direção e se cancelam: `.timestamp()` de um naive interpreta como horário local, tanto no `session['reset_expires_at']` quanto no countdown. Mudar só um lado para aware quebraria o countdown exibido pelo offset do fuso. Por isso os três mudam juntos.

## Correção
- 3× `datetime.utcnow()` → `datetime.now(timezone.utc)`.
- `get_valid_token`: `NOW()` → `UTC_TIMESTAMP()`.

## Verificação da armadilha do connector (testada, não presumida)
Rodei mysql-connector contra o banco de teste (servidor em UTC-3):

| | valor |
|---|---|
| `NOW()` | `20:12` (local) |
| `UTC_TIMESTAMP()` | `23:12` (UTC) |
| datetime aware-UTC inserido | gravado como `23:27` (**wall-clock UTC**) |

Ou seja: o valor gravado é UTC, então só `UTC_TIMESTAMP()` compara corretamente. Num servidor em UTC-3, o `NOW()` antigo aceitaria um token **já expirado em UTC** por até 3h.

## Teste
`test_get_valid_token_usa_utc_nao_fuso_do_servidor`: token expirado há 1 min em UTC deve ser rejeitado; token de 15 min deve ser aceito. Verifiquei que **falha com `NOW()` e passa com `UTC_TIMESTAMP()`** no CI (UTC-3).

Bônus: zerou os `DeprecationWarning` de `utcnow` que apareciam em toda run. `grep utcnow` no projeto: nenhum restante. Suíte: 314 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)