### PR TITLE
chore: documenta REDIS_URL e adiciona heartbeat do scheduler

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -9,6 +9,11 @@ DB_POOL_SIZE=   # tamanho do pool de conexões, default 5
 # Segurança
 SECRET_KEY=     # chave secreta Flask — gere com: python -c "import secrets; print(secrets.token_hex(32))"
 
+# Rate limiter (Flask-Limiter) — OBRIGATÓRIO em produção com múltiplos workers.
+# gunicorn.conf.py roda 3 workers; sem REDIS_URL cada um mantém seu próprio
+# contador em memória e os limites (ex: 10/min no login) valem ~3x. Ver #80.
+REDIS_URL=      # ex: redis://default:senha@host:6379  (vazio = memory:// por worker, só dev)
+
 # Bootstrap do usuário 'admin' — SOMENTE em ambiente local.
 # Deixe SEED_ADMIN vazio em produção: init_db.py roda a cada deploy e criaria
 # uma conta de acesso com senha conhecida. Sem estas vars, só o schema é criado.

--- a/app.py
+++ b/app.py
@@ -195,6 +195,18 @@ if _sched_permitido:
     scheduler.add_job(verificar_protocolos_vencendo,'cron', hour=8, args=[app])
     scheduler.add_job(verificar_estoque_critico,    'cron', day_of_week='mon', hour=8, args=[app])
     scheduler.add_job(verificar_feedback_7dias,     'cron', hour=9, args=[app])
+
+    # Heartbeat observável: um listener cobre todos os jobs (atuais e futuros).
+    # Sem isso, o scheduler parando ou duplicando é silencioso — ver #80.
+    from apscheduler.events import EVENT_JOB_EXECUTED, EVENT_JOB_ERROR
+
+    def _log_job(event):
+        if event.exception:
+            logging.getLogger('scheduler').error("Job %s FALHOU", event.job_id, exc_info=event.exception)
+        else:
+            logging.getLogger('scheduler').info("Job %s executou", event.job_id)
+
+    scheduler.add_listener(_log_job, EVENT_JOB_EXECUTED | EVENT_JOB_ERROR)
     scheduler.start()
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #80

## Contexto
Dois sintomas silenciosos ao escalar horizontalmente.

### Rate limiter
`extensions.py:9-13` cai para `memory://` sem `REDIS_URL`, e `gunicorn.conf.py` roda 3 workers → 3 contadores independentes fazem `@limiter.limit("10 per minute")` do login valer ~30/min. **O código já suporta Redis** (`storage_uri=_REDIS_URL if _REDIS_URL else "memory://"`) — só faltava documentar a var. Adicionada ao `.env-example` com o porquê.

### Scheduler
Um **único listener** (`EVENT_JOB_EXECUTED | EVENT_JOB_ERROR`) registrado em `app.py` loga cada execução — sucesso em INFO, falha em ERROR com traceback. Cobre os 4 jobs atuais e qualquer futuro, sem tocar nas funções de `alertas.py`. Sem isso, o scheduler parando ou duplicando é invisível.

## Decisão de escopo
**Não externalizei o scheduler.** O diagnóstico sugeria "externalizar/monitorar antes de replicar". Uma réplica não justifica um broker novo; o heartbeat resolve o "invisível". Reavaliar se/quando houver múltiplas réplicas.

`REDIS_URL` é config de produção (Railway) — provisionar o Redis lá é o passo operacional que fecha o lado do rate limiter; o código não precisa de mais nada.

## Verificação
`app.py` compila. Smoke-test de um `BackgroundScheduler` com o listener: job de sucesso loga info, job que levanta exceção loga error — confirmado (`[('info','ok_job'), ('error','bad_job')]`). O bloco do scheduler não roda no CI (`SCHEDULER_ENABLED=false`), então a suíte não muda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)