### PR TITLE
docs: formaliza política de migração só-aditiva de schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,20 @@ O banco não armazena dados brutos para o Python calcular. Cada view encapsula u
 | `vw_gmd_por_touro` | Ranking de touros por GMD médio dos filhos |
 | `vw_saldo_estoque` | Saldo de estoque com flag de mínimo atingido |
 
+### Migrações de schema — política só-aditiva
+
+Não há Alembic. O schema vive inteiro em `init_db.py` como DDL idempotente
+(`CREATE TABLE IF NOT EXISTS`, `CREATE OR REPLACE VIEW`, `ALTER` protegido por errno),
+rodada a cada deploy pelo `railway.toml`. A decisão é **manter esse padrão só-aditivo**:
+sem ORM, ~20 ALTERs convergentes não justificam uma ferramenta de migração.
+
+- **Direto no `init_db.py`:** tabela, view ou índice novos; coluna *nullable* ou com `DEFAULT`.
+- **Exige script one-shot em `migrations/`, rodado à mão, fora do `preDeployCommand`:**
+  renomear, mudar tipo, `NOT NULL` sem default em tabela populada, ou qualquer backfill.
+
+DDL destrutiva nunca entra no `init_db.py` nem no `preDeployCommand` — como roda a cada
+deploy, seria irreversível. Reavaliar adotar migração versionada na primeira mudança desse tipo.
+
 ## Testes
 
 ### Testes unitários e de integração


### PR DESCRIPTION
Closes #78

## Decisão
O #78 pedia uma escolha antes da próxima mudança destrutiva: migração versionada **ou** formalizar por escrito o padrão só-aditivo. Este PR formaliza o padrão — **sem** Alembic.

**Por quê não Alembic:** SQL puro, sem ORM, ~20 ALTERs idempotentes convergentes em `init_db.py`. Alembic custaria mais manutenção do que resolve hoje. A dor real só aparece na primeira mudança destrutiva — e a doc diz o que fazer nesse dia.

## Onde
Seção nova em **`README.md`** (rastreado). Nota: `CLAUDE.md` está no `.gitignore` deste repo, então a política precisava de um arquivo versionado para valer para o time — daí o README, ao lado da seção "Estrutura de banco" que já existe.

## Conteúdo
- **Direto no `init_db.py`:** tabela/view/índice novos, coluna nullable ou com default.
- **Exige script one-shot em `migrations/`, à mão, fora do `preDeployCommand`:** rename, tipo, `NOT NULL` sem default em tabela populada, backfill.
- DDL destrutiva nunca no `init_db.py`/`preDeployCommand` — roda a cada deploy, seria irreversível.

Só documentação; sem impacto em código ou testes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)