### PR TITLE
feat(painel): ordena o rebanho por peso e GMD no servidor

### DIFF
--- a/app.py
+++ b/app.py
@@ -80,6 +80,25 @@ def format_date_br(value):
     return str(value)
 
 
+@app.template_global()
+def painel_url(**overrides):
+    """URL do painel preservando os filtros que já estão na query string.
+
+    Existe porque cada link de filtro do painel precisava repassar busca,
+    status, raça, origem, sexo (e agora a ordenação) na mão — seis parâmetros
+    em uma dúzia de links, onde esquecer um significa perder silenciosamente o
+    filtro do usuário.
+
+    Voltar para a página 1 é o padrão: mudar filtro ou ordenação invalida a
+    página em que se estava. Só a paginação passa `page` explicitamente.
+    """
+    args = {**request.args.to_dict(), **overrides}
+    if 'page' not in overrides:
+        args.pop('page', None)
+    return url_for('operacional.painel',
+                   **{k: v for k, v in args.items() if v not in (None, '')})
+
+
 @app.context_processor
 def inject_user_info():
     if not current_user.is_authenticated:

--- a/repositories/animal_repository.py
+++ b/repositories/animal_repository.py
@@ -79,6 +79,42 @@ def _gmd_ctes(join_clause: str) -> str:
     )
 
 
+# ---- ORDENAÇÃO DA LISTAGEM ----
+
+# Whitelist das ordenações do painel: a CHAVE vem da query string, o VALOR nunca.
+# Mesma regra de _build_animais_where — só literal hardcoded entra no SQL.
+#
+# O segundo item diz se a ordenação exige as CTEs de GMD. Quem ordena por brinco
+# (o padrão, a maioria dos acessos) continua sem pagar a window function sobre
+# `pesagens`; o custo só aparece para quem realmente pediu peso/GMD.
+#
+# O `<coluna> IS NULL` antes do critério empurra os NULLs para o fim nos DOIS
+# sentidos. Sem isso, "menor GMD" abriria com a tela cheia de animais de uma
+# pesagem só (NULL vem primeiro no ASC do MySQL) em vez do pior boi medido.
+ORDENACAO_PADRAO = 'brinco'
+_ORDENACOES = {
+    'brinco':    ("LENGTH(a.brinco) ASC, a.brinco ASC",      False),
+    'gmd_desc':  ("g.gmd IS NULL, g.gmd DESC",               True),
+    'gmd_asc':   ("g.gmd IS NULL, g.gmd ASC",                True),
+    'peso_desc': ("g.peso_final IS NULL, g.peso_final DESC", True),
+    'peso_asc':  ("g.peso_final IS NULL, g.peso_final ASC",  True),
+}
+
+
+def normalizar_ordenacao(ordem):
+    """Reduz o que veio da query string a uma chave conhecida de _ORDENACOES."""
+    return ordem if ordem in _ORDENACOES else ORDENACAO_PADRAO
+
+
+def ordenacao_traz_gmd(ordem):
+    """True quando get_animais_paginados já devolve peso/GMD preenchidos.
+
+    O front usa isso para pular a chamada a /api/animais/gmd-lote: os valores
+    foram calculados de qualquer forma para o ORDER BY.
+    """
+    return _ORDENACOES[normalizar_ordenacao(ordem)][1]
+
+
 # ---- LISTAGENS E CONTAGENS ----
 
 def count_animais(user_id, termo=None, status='todos', raca=None, origem=None, sexo=None):
@@ -88,15 +124,46 @@ def count_animais(user_id, termo=None, status='todos', raca=None, origem=None, s
         return cursor.fetchone()[0]
 
 
-def get_animais_paginados(user_id, limit, offset, termo=None, status='todos', raca=None, origem=None, sexo=None):
+def get_animais_paginados(user_id, limit, offset, termo=None, status='todos', raca=None,
+                          origem=None, sexo=None, ordem=ORDENACAO_PADRAO):
+    """Uma página do rebanho, na ordem pedida.
+
+    Devolve sempre 10 colunas. As duas últimas (peso_final, gmd) só vêm
+    preenchidas quando a ordenação as exigiu — ver ordenacao_traz_gmd.
+    """
+    order_sql, precisa_gmd = _ORDENACOES[normalizar_ordenacao(ordem)]
     where, params = _build_animais_where(user_id, termo, status, raca=raca, origem=origem, sexo=sexo, alias='a.')
-    sql = (
-        "SELECT a.id, a.brinco, a.sexo, a.raca, a.data_compra, a.preco_compra, "
-        "       a.data_venda, a.preco_venda "
-        "FROM animais a "
-        + where +
-        " ORDER BY LENGTH(a.brinco) ASC, a.brinco ASC LIMIT %s OFFSET %s"
-    )
+    colunas = ("a.id, a.brinco, a.sexo, a.raca, a.data_compra, a.preco_compra, "
+               "a.data_venda, a.preco_venda")
+    # a.id fecha todo ORDER BY: sem coluna única no critério, linhas empatadas
+    # (o bloco inteiro de gmd NULL, por exemplo) podem repetir numa página e
+    # sumir da seguinte, porque o MySQL não promete ordem estável no empate.
+    final = " ORDER BY " + order_sql + ", a.id ASC LIMIT %s OFFSET %s"
+
+    if precisa_gmd:
+        sql = _gmd_ctes(
+            "JOIN animais a ON a.id = p.animal_id"
+            "    AND a.user_id = %s AND a.deleted_at IS NULL"
+            "    AND p.deleted_at IS NULL"
+        ) + (
+            ","
+            " gmd_calc AS ("
+            "  SELECT animal_id, peso_fim AS peso_final,"
+            "    CASE WHEN DATEDIFF(data_fim, data_ini) > 0"
+            "      THEN ROUND((peso_fim - peso_ini) / DATEDIFF(data_fim, data_ini), 3)"
+            "      ELSE NULL END AS gmd"
+            "  FROM pu"
+            " )"
+            " SELECT " + colunas + ", g.peso_final, g.gmd"
+            " FROM animais a"
+            " LEFT JOIN gmd_calc g ON g.animal_id = a.id "
+        ) + where + final
+        # o %s do JOIN da CTE é o primeiro placeholder da query
+        params = [user_id] + params
+    else:
+        sql = ("SELECT " + colunas + ", NULL AS peso_final, NULL AS gmd "
+               "FROM animais a " + where + final)
+
     with get_db_cursor() as cursor:
         cursor.execute(sql, tuple(params + [limit, offset]))
         return cursor.fetchall()

--- a/routes/operacional.py
+++ b/routes/operacional.py
@@ -24,6 +24,7 @@ def painel():
     sexo = request.args.get('sexo', '') or None
     if sexo not in ('M', 'F'):
         sexo = None
+    ordem = animal_repository.normalizar_ordenacao(request.args.get('ord', ''))
     pg = request.args.get('page', 1, type=int)
     limit, offset = 20, (pg - 1) * 20
     total_pg = 1
@@ -35,7 +36,7 @@ def painel():
         racas_disponiveis = animal_repository.get_racas_distintas(current_user.id)
         total = animal_repository.count_animais(current_user.id, termo, status, raca=raca, origem=origem, sexo=sexo)
         animais = animal_repository.get_animais_paginados(current_user.id, limit, offset, termo, status,
-                                                           raca=raca, origem=origem, sexo=sexo)
+                                                           raca=raca, origem=origem, sexo=sexo, ordem=ordem)
         if total > 0:
             total_pg = math.ceil(total / limit)
         alertas_sanitarios = sanitario_repository.get_vencendo_em_dias(current_user.id, dias=7)
@@ -47,6 +48,8 @@ def painel():
                            total_paginas=total_pg, total_animais=total, busca=termo, status=status,
                            raca_filtro=raca or '', racas_disponiveis=racas_disponiveis,
                            origem_filtro=origem or '', sexo_filtro=sexo or '',
+                           ordenacao=ordem,
+                           gmd_embutido=animal_repository.ordenacao_traz_gmd(ordem),
                            alertas_sanitarios=alertas_sanitarios)
 
 @operacional_bp.route('/lixeira')

--- a/static/css/design_system.css
+++ b/static/css/design_system.css
@@ -1900,6 +1900,16 @@ textarea:not(.form-textarea):focus {
   gap: var(--space-2);
 }
 
+/* Select dentro da toolbar de filtros: o .form-select padrão é width:100% (feito
+   para formulário em coluna) e esticaria a linha inteira aqui. */
+.filter-select {
+  width: auto;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  padding: 6px var(--space-3);
+  min-height: 34px;   /* mesma altura dos .chip ao lado */
+}
+
 .filter-group__label {
   font-size: var(--text-xs);
   font-weight: var(--weight-medium);

--- a/templates/index.html
+++ b/templates/index.html
@@ -159,6 +159,7 @@
   <input type="hidden" name="raca" value="{{ raca_filtro }}">
   <input type="hidden" name="origem" value="{{ origem_filtro }}">
   <input type="hidden" name="sexo" value="{{ sexo_filtro }}">
+  <input type="hidden" name="ord" value="{{ ordenacao }}">
 
   <div class="combo">
     <label class="sr-only" for="busca-brinco">Número do brinco</label>
@@ -190,25 +191,25 @@
 
     <div class="filter-group" role="group" aria-label="Filtrar por situação">
       <span class="filter-group__label" aria-hidden="true">Exibir</span>
-      <a href="{{ url_for('operacional.painel', status='todos',    busca=busca, raca=raca_filtro, origem=origem_filtro, sexo=sexo_filtro) }}"
+      <a href="{{ painel_url(status='todos') }}"
          class="chip"{% if status == 'todos' %} aria-current="true"{% endif %}>Todos</a>
-      <a href="{{ url_for('operacional.painel', status='ativos',   busca=busca, raca=raca_filtro, origem=origem_filtro, sexo=sexo_filtro) }}"
+      <a href="{{ painel_url(status='ativos') }}"
          class="chip"{% if status == 'ativos' %} aria-current="true"{% endif %}>Ativos</a>
-      <a href="{{ url_for('operacional.painel', status='vendidos', busca=busca, raca=raca_filtro, origem=origem_filtro, sexo=sexo_filtro) }}"
+      <a href="{{ painel_url(status='vendidos') }}"
          class="chip"{% if status == 'vendidos' %} aria-current="true"{% endif %}>Vendidos</a>
-      <a href="{{ url_for('operacional.painel', status=status, busca=busca, raca=raca_filtro, origem='' if origem_filtro == 'fazenda' else 'fazenda', sexo=sexo_filtro) }}"
+      <a href="{{ painel_url(origem='' if origem_filtro == 'fazenda' else 'fazenda') }}"
          class="chip"{% if origem_filtro == 'fazenda' %} aria-current="true"{% endif %}
          title="Animais nascidos na própria fazenda (sem data de compra)">Nascidos na Fazenda</a>
     </div>
 
     <div class="filter-group" role="group" aria-label="Filtrar por sexo">
       <span class="filter-group__label" aria-hidden="true">Sexo</span>
-      <a href="{{ url_for('operacional.painel', status=status, busca=busca, raca=raca_filtro, origem=origem_filtro) }}"
+      <a href="{{ painel_url(sexo='') }}"
          class="chip"{% if not sexo_filtro %} aria-current="true"{% endif %}>Todos</a>
-      <a href="{{ url_for('operacional.painel', status=status, busca=busca, raca=raca_filtro, origem=origem_filtro, sexo='M') }}"
+      <a href="{{ painel_url(sexo='M') }}"
          class="chip"{% if sexo_filtro == 'M' %} aria-current="true"{% endif %}
          title="Recalcula o GMD médio considerando só machos">Machos</a>
-      <a href="{{ url_for('operacional.painel', status=status, busca=busca, raca=raca_filtro, origem=origem_filtro, sexo='F') }}"
+      <a href="{{ painel_url(sexo='F') }}"
          class="chip"{% if sexo_filtro == 'F' %} aria-current="true"{% endif %}
          title="Recalcula o GMD médio considerando só fêmeas">Fêmeas</a>
     </div>
@@ -216,14 +217,36 @@
     {% if racas_disponiveis | length > 1 %}
     <div class="filter-group" role="group" aria-label="Filtrar por raça">
       <span class="filter-group__label" aria-hidden="true">Raça</span>
-      <a href="{{ url_for('operacional.painel', status=status, busca=busca, origem=origem_filtro, sexo=sexo_filtro) }}"
+      <a href="{{ painel_url(raca='') }}"
          class="chip"{% if not raca_filtro %} aria-current="true"{% endif %}>Todas</a>
       {% for r in racas_disponiveis %}
-      <a href="{{ url_for('operacional.painel', status=status, busca=busca, raca=r, origem=origem_filtro, sexo=sexo_filtro) }}"
+      <a href="{{ painel_url(raca=r) }}"
          class="chip"{% if raca_filtro == r %} aria-current="true"{% endif %}>{{ r }}</a>
       {% endfor %}
     </div>
     {% endif %}
+
+    {# Ordenação como <select>, não como cabeçalho clicável: as colunas peso e
+       GMD somem em tela estreita (ver a <caption> da tabela), e no celular não
+       sobraria cabeçalho nenhum para clicar. O botão "Aplicar" existe para
+       quem está sem JS; o script o esconde e submete no change. #}
+    <form action="{{ url_for('operacional.painel') }}" method="GET"
+          class="filter-group" id="form-ordenacao">
+      <input type="hidden" name="busca" value="{{ busca }}">
+      <input type="hidden" name="status" value="{{ status }}">
+      <input type="hidden" name="raca" value="{{ raca_filtro }}">
+      <input type="hidden" name="origem" value="{{ origem_filtro }}">
+      <input type="hidden" name="sexo" value="{{ sexo_filtro }}">
+      <label class="filter-group__label" for="ord">Ordenar</label>
+      <select name="ord" id="ord" class="form-select filter-select">
+        <option value="brinco"    {% if ordenacao == 'brinco'    %}selected{% endif %}>Brinco</option>
+        <option value="gmd_desc"  {% if ordenacao == 'gmd_desc'  %}selected{% endif %}>GMD — maior primeiro</option>
+        <option value="gmd_asc"   {% if ordenacao == 'gmd_asc'   %}selected{% endif %}>GMD — menor primeiro</option>
+        <option value="peso_desc" {% if ordenacao == 'peso_desc' %}selected{% endif %}>Peso — maior primeiro</option>
+        <option value="peso_asc"  {% if ordenacao == 'peso_asc'  %}selected{% endif %}>Peso — menor primeiro</option>
+      </select>
+      <button type="submit" class="btn btn-secondary btn-sm" id="btn-aplicar-ord">Aplicar</button>
+    </form>
 
   </div>
   <a href="{{ url_for('operacional.lixeira') }}" class="btn btn-sm btn-ghost ml-auto shrink-0">
@@ -244,15 +267,27 @@
         <th scope="col">Brinco</th>
         <th scope="col">Sexo</th>
         <th scope="col">Raça</th>
-        <th scope="col" class="col-peso num">Último peso (kg)</th>
-        <th scope="col" class="col-gmd num" title="Ganho Médio Diário — kg/dia de ganho de peso">GMD kg/dia</th>
+        {# aria-sort anuncia ao leitor de tela por qual coluna a lista está
+           ordenada — o controle é o <select> "Ordenar" acima. #}
+        <th scope="col" class="col-peso num"
+            aria-sort="{% if ordenacao == 'peso_asc' %}ascending{% elif ordenacao == 'peso_desc' %}descending{% else %}none{% endif %}">Último peso (kg)</th>
+        <th scope="col" class="col-gmd num" title="Ganho Médio Diário — kg/dia de ganho de peso"
+            aria-sort="{% if ordenacao == 'gmd_asc' %}ascending{% elif ordenacao == 'gmd_desc' %}descending{% else %}none{% endif %}">GMD kg/dia</th>
         <th scope="col">Status</th>
         <th scope="col"><span class="sr-only">Ações</span></th>
       </tr>
     </thead>
-    <tbody>
+    {# Quando a ordenação foi por peso/GMD, o servidor já calculou os valores
+       para o ORDER BY e os manda aqui: o JS pinta as células com esses dados e
+       poupa o round-trip a /api/animais/gmd-lote. Sem isso a coluna ordenada
+       ficaria em skeleton por um instante — a lista pareceria fora de ordem. #}
+    <tbody{% if gmd_embutido %} data-gmd-embutido="1"{% endif %}>
       {% for animal in lista_animais %}
-      <tr data-aid="{{ animal[0] }}">
+      <tr data-aid="{{ animal[0] }}"
+          {%- if gmd_embutido %}
+          {% if animal[8] is not none %}data-peso="{{ animal[8] }}"{% endif %}
+          {% if animal[9] is not none %}data-gmd="{{ animal[9] }}"{% endif %}
+          {%- endif %}>
         <th scope="row" class="td-primary" style="font-weight:var(--weight-medium); text-align:left;">{{ animal[1] }}</th>
         <td>{{ 'Macho' if animal[2] == 'M' else 'Fêmea' }}</td>
         <td>{{ animal[3] or '—' }}</td>
@@ -308,7 +343,8 @@
     {% endif %}
   </span>
 {{ m.paginacao('operacional.painel', pagina_atual, total_paginas,
-               busca=busca, status=status, raca=raca_filtro, origem=origem_filtro, sexo=sexo_filtro) }}
+               busca=busca, status=status, raca=raca_filtro, origem=origem_filtro,
+               sexo=sexo_filtro, ord=ordenacao) }}
 </div>
 
 <!-- ── Modal Cotações Brasil ───────────────────────────── -->
@@ -555,47 +591,65 @@ function faixaGMD(g) {
   return { classe: 'perf-baixo', glifo: '▼', texto: 'abaixo da meta' };
 }
 
+const GMD_DASH = '<span class="data-empty">—</span>';
+
+/* Renderizador único das duas células. `data` é {id: [peso, gmd]}, venha da
+   API ou dos data-attributes que o servidor embutiu ao ordenar por peso/GMD —
+   um só lugar decide como a célula fica. */
+function pintarLinhasGMD(rows, data) {
+  rows.forEach(row => {
+    const entry  = data[row.dataset.aid];
+    const pesoTd = row.querySelector('.col-peso');
+    const gmdTd  = row.querySelector('.col-gmd');
+    if (!pesoTd || !gmdTd) return;
+
+    if (!entry) { pesoTd.innerHTML = GMD_DASH; gmdTd.innerHTML = GMD_DASH; return; }
+
+    const [peso, gmd] = entry;
+    pesoTd.innerHTML = peso ? sggNum(peso, 1) : GMD_DASH;
+
+    if (gmd === null || gmd === undefined) { gmdTd.innerHTML = GMD_DASH; return; }
+    const g = parseFloat(gmd);
+    const f = faixaGMD(g);
+    /* A barra é proporcional à meta e dá a leitura da distribuição do lote
+       de relance. O glifo e o texto oculto garantem que o significado não
+       dependa da cor nem da barra. */
+    const larg = Math.max(2, Math.min(100, (g / GMD_META) * 100));
+    gmdTd.innerHTML =
+      `<span class="gmd-cell ${f.classe}">` +
+        `<span class="gmd-cell__valor">` +
+          `<span aria-hidden="true">${f.glifo}</span> ${sggNum(g, 3)}` +
+        `</span>` +
+        `<span class="gmd-cell__barra" aria-hidden="true"><i style="width:${larg}%"></i></span>` +
+        `<span class="sr-only"> kg por dia, ${f.texto}</span>` +
+      `</span>`;
+  });
+}
+
 async function carregarGMDTabela() {
   const rows = document.querySelectorAll('tr[data-aid]');
   if (!rows.length) return;
+
+  /* Ordenado por peso/GMD: o servidor já mandou os números junto com o HTML.
+     Nada a buscar. */
+  if (document.querySelector('tbody[data-gmd-embutido]')) {
+    const embutido = {};
+    rows.forEach(r => {
+      embutido[r.dataset.aid] = [r.dataset.peso ?? null, r.dataset.gmd ?? null];
+    });
+    pintarLinhasGMD(rows, embutido);
+    return;
+  }
+
   const ids = Array.from(rows).map(r => r.dataset.aid).join(',');
-  const dash = '<span class="data-empty">—</span>';
   try {
     const res = await fetch('/api/animais/gmd-lote?ids=' + ids);
     if (!res.ok) throw new Error(res.status);
-    const data = await res.json();
-
-    rows.forEach(row => {
-      const entry  = data[row.dataset.aid];
-      const pesoTd = row.querySelector('.col-peso');
-      const gmdTd  = row.querySelector('.col-gmd');
-      if (!pesoTd || !gmdTd) return;
-
-      if (!entry) { pesoTd.innerHTML = dash; gmdTd.innerHTML = dash; return; }
-
-      const [peso, gmd] = entry;
-      pesoTd.innerHTML = peso ? sggNum(peso, 1) : dash;
-
-      if (gmd === null || gmd === undefined) { gmdTd.innerHTML = dash; return; }
-      const g = parseFloat(gmd);
-      const f = faixaGMD(g);
-      /* A barra é proporcional à meta e dá a leitura da distribuição do lote
-         de relance. O glifo e o texto oculto garantem que o significado não
-         dependa da cor nem da barra. */
-      const larg = Math.max(2, Math.min(100, (g / GMD_META) * 100));
-      gmdTd.innerHTML =
-        `<span class="gmd-cell ${f.classe}">` +
-          `<span class="gmd-cell__valor">` +
-            `<span aria-hidden="true">${f.glifo}</span> ${sggNum(g, 3)}` +
-          `</span>` +
-          `<span class="gmd-cell__barra" aria-hidden="true"><i style="width:${larg}%"></i></span>` +
-          `<span class="sr-only"> kg por dia, ${f.texto}</span>` +
-        `</span>`;
-    });
+    pintarLinhasGMD(rows, await res.json());
   } catch (e) {
     console.error('Erro ao carregar GMD:', e);
     document.querySelectorAll('tr[data-aid] .col-peso, tr[data-aid] .col-gmd').forEach(td => {
-      td.innerHTML = dash;
+      td.innerHTML = GMD_DASH;
     });
     sggToast('Peso e GMD da tabela não puderam ser carregados. Recarregue a página para tentar de novo.', 'warning');
   }
@@ -691,6 +745,14 @@ document.addEventListener('DOMContentLoaded', function () {
     if (e.key === 'Escape' && soltarFocoModal) fecharModalBrasil();
   });
   document.getElementById('btn-recarregar-metricas').addEventListener('click', carregarMetricas);
+
+  /* Com JS, escolher a ordem já recarrega: o botão "Aplicar" é o fallback de
+     quem está sem script, e some para não virar um passo extra. */
+  const formOrd = document.getElementById('form-ordenacao');
+  if (formOrd) {
+    document.getElementById('btn-aplicar-ord').hidden = true;
+    document.getElementById('ord').addEventListener('change', () => formOrd.submit());
+  }
 
   carregarMetricas();
   carregarCotacao();

--- a/tests/test_ordenacao_painel.py
+++ b/tests/test_ordenacao_painel.py
@@ -1,0 +1,262 @@
+"""
+Ordenação do painel por peso e GMD.
+Repositório: animal_repository.get_animais_paginados (parâmetro ordem)
+Rota: GET /painel?ord=gmd_desc|gmd_asc|peso_desc|peso_asc|brinco
+"""
+import pytest
+import itertools
+from werkzeug.security import generate_password_hash
+import db_config as dbc
+from repositories import animal_repository
+
+_seq = itertools.count(21000)
+
+
+def _n():
+    return next(_seq)
+
+
+def _make_user():
+    conn = dbc.get_db_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO usuarios (username, password_hash) VALUES (%s, %s)",
+        (f"ord_{_n()}", generate_password_hash("x")),
+    )
+    uid = cur.lastrowid
+    conn.commit(); cur.close(); conn.close()
+    return uid
+
+
+def _make_animal(user_id, brinco):
+    conn = dbc.get_db_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO animais (brinco, sexo, data_compra, preco_compra, user_id)"
+        " VALUES (%s, 'M', '2024-01-01', 1000, %s)",
+        (brinco, user_id),
+    )
+    aid = cur.lastrowid
+    conn.commit(); cur.close(); conn.close()
+    return aid
+
+
+def _add_pesagem(animal_id, data, peso):
+    conn = dbc.get_db_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO pesagens (animal_id, data_pesagem, peso) VALUES (%s, %s, %s)",
+        (animal_id, data, peso),
+    )
+    conn.commit(); cur.close(); conn.close()
+
+
+def _purge(user_id):
+    conn = dbc.get_db_connection()
+    cur = conn.cursor()
+    cur.execute("SET FOREIGN_KEY_CHECKS = 0")
+    for sql in [
+        "DELETE p FROM pesagens p JOIN animais a ON p.animal_id = a.id WHERE a.user_id = %s",
+        "DELETE FROM animais WHERE user_id = %s",
+        "DELETE FROM usuarios WHERE id = %s",
+    ]:
+        cur.execute(sql, (user_id,))
+    cur.execute("SET FOREIGN_KEY_CHECKS = 1")
+    conn.commit(); cur.close(); conn.close()
+
+
+def _login(client, uid):
+    conn = dbc.get_db_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT username FROM usuarios WHERE id = %s", (uid,))
+    username = cur.fetchone()[0]
+    cur.close(); conn.close()
+    client.post("/login", data={"username": username, "password": "x"}, follow_redirects=True)
+
+
+@pytest.fixture
+def um(app):
+    uid = _make_user()
+    yield uid
+    _purge(uid)
+
+
+@pytest.fixture
+def trio(um):
+    """Três animais que separam peso de GMD:
+
+    RAPIDO  200 → 320 kg em 60 dias → GMD 2.0, peso final 320
+    LENTO   200 → 260 kg em 60 dias → GMD 1.0, peso final 260
+    PESADO  uma pesagem só de 400 kg → GMD NULL, mas o MAIOR peso do lote
+
+    PESADO é o que importa: sem ele, um bug que confunda "sem GMD" com "GMD
+    baixo" passaria despercebido, porque peso e GMD andariam juntos.
+    """
+    rapido = _make_animal(um, f"RAPIDO{_n()}")
+    lento  = _make_animal(um, f"LENTO{_n()}")
+    pesado = _make_animal(um, f"PESADO{_n()}")
+    _add_pesagem(rapido, '2024-01-01', 200); _add_pesagem(rapido, '2024-03-01', 320)
+    _add_pesagem(lento,  '2024-01-01', 200); _add_pesagem(lento,  '2024-03-01', 260)
+    _add_pesagem(pesado, '2024-01-01', 400)
+    return um, rapido, lento, pesado
+
+
+def _ids(um, ordem):
+    return [a[0] for a in animal_repository.get_animais_paginados(um, 20, 0, ordem=ordem)]
+
+
+# ── repositório: ordem ───────────────────────────────────────────────────────
+
+def test_gmd_desc_traz_o_melhor_primeiro(trio):
+    um, rapido, lento, pesado = trio
+    assert _ids(um, 'gmd_desc') == [rapido, lento, pesado]
+
+
+def test_gmd_asc_traz_o_pior_medido_primeiro_e_o_sem_gmd_por_ultimo(trio):
+    """O ponto do `g.gmd IS NULL` no ORDER BY: quem pede "menor GMD" quer o pior
+    boi medido. No ASC puro do MySQL o NULL viria primeiro e a tela abriria com
+    animais de uma pesagem só."""
+    um, rapido, lento, pesado = trio
+    assert _ids(um, 'gmd_asc') == [lento, rapido, pesado]
+
+
+def test_peso_desc_ordena_pelo_ultimo_peso(trio):
+    um, rapido, lento, pesado = trio
+    assert _ids(um, 'peso_desc') == [pesado, rapido, lento]
+
+
+def test_peso_asc_ordena_pelo_ultimo_peso(trio):
+    um, rapido, lento, pesado = trio
+    assert _ids(um, 'peso_asc') == [lento, rapido, pesado]
+
+
+def test_ordem_padrao_continua_por_brinco(trio):
+    um, _, _, _ = trio
+    brincos = [a[1] for a in animal_repository.get_animais_paginados(um, 20, 0)]
+    assert brincos == sorted(brincos, key=lambda b: (len(b), b))
+
+
+# ── repositório: colunas peso/GMD ────────────────────────────────────────────
+
+def test_ordem_por_brinco_nao_calcula_gmd(trio):
+    """As colunas 8 e 9 vêm vazias no caminho barato — o painel continua
+    buscando os valores por /api/animais/gmd-lote."""
+    um, _, _, _ = trio
+    assert not animal_repository.ordenacao_traz_gmd('brinco')
+    for animal in animal_repository.get_animais_paginados(um, 20, 0):
+        assert animal[8] is None and animal[9] is None
+
+
+def test_ordem_por_gmd_ja_devolve_peso_e_gmd(trio):
+    um, rapido, _, pesado = trio
+    assert animal_repository.ordenacao_traz_gmd('gmd_desc')
+    linhas = {a[0]: a for a in animal_repository.get_animais_paginados(um, 20, 0, ordem='gmd_desc')}
+
+    assert float(linhas[rapido][8]) == 320
+    assert float(linhas[rapido][9]) == 2.0
+    # uma pesagem só: tem peso, não tem GMD
+    assert float(linhas[pesado][8]) == 400
+    assert linhas[pesado][9] is None
+
+
+# ── repositório: robustez ────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("lixo", [
+    "", "gmd", "brinco; DROP TABLE animais", "a.brinco DESC", None,
+])
+def test_ordenacao_desconhecida_cai_no_padrao(trio, lixo):
+    """Só a chave vem de fora; o SQL é literal. Qualquer coisa fora da whitelist
+    vira a ordenação padrão em vez de chegar ao banco."""
+    um, _, _, _ = trio
+    assert animal_repository.normalizar_ordenacao(lixo) == 'brinco'
+    assert _ids(um, lixo) == _ids(um, 'brinco')
+
+
+def test_paginacao_por_gmd_nao_repete_nem_perde_animal(um):
+    """Empate em massa (todos sem GMD) é onde falta de desempate estável dói:
+    sem o `a.id` no fim do ORDER BY, o mesmo animal aparece em duas páginas."""
+    for i in range(6):
+        _make_animal(um, f"EMP{i}{_n()}")
+
+    p1 = [a[0] for a in animal_repository.get_animais_paginados(um, 3, 0, ordem='gmd_desc')]
+    p2 = [a[0] for a in animal_repository.get_animais_paginados(um, 3, 3, ordem='gmd_desc')]
+
+    assert len(set(p1 + p2)) == 6
+
+
+def test_ordenacao_por_gmd_respeita_o_filtro(trio):
+    um, rapido, lento, pesado = trio
+    ids = [a[0] for a in animal_repository.get_animais_paginados(
+        um, 20, 0, termo='RAPIDO', ordem='gmd_desc')]
+    assert ids == [rapido]
+
+
+def test_ordenacao_por_gmd_nao_vaza_animal_de_outro_usuario(trio):
+    """A CTE de GMD é um caminho de query novo — o filtro por user_id precisa
+    valer nele também."""
+    um, _, _, _ = trio
+    outro = _make_user()
+    try:
+        alheio = _make_animal(outro, f"ALHEIO{_n()}")
+        _add_pesagem(alheio, '2024-01-01', 100)
+        _add_pesagem(alheio, '2024-03-01', 900)  # GMD altíssimo: seria o 1º da lista
+
+        assert alheio not in _ids(um, 'gmd_desc')
+        assert alheio not in _ids(um, 'peso_desc')
+    finally:
+        _purge(outro)
+
+
+# ── rota ─────────────────────────────────────────────────────────────────────
+
+def test_rota_painel_ordena_por_gmd(app, trio):
+    um, rapido, lento, pesado = trio
+    with app.test_client() as client:
+        _login(client, um)
+        html = client.get('/painel?ord=gmd_desc').get_data(as_text=True)
+
+    assert html.index('RAPIDO') < html.index('LENTO') < html.index('PESADO')
+
+
+def test_rota_painel_embute_peso_e_gmd_ao_ordenar(app, trio):
+    """Ordenando por GMD a página já traz os números, e o front não repete a
+    chamada a /api/animais/gmd-lote."""
+    um, _, _, _ = trio
+    with app.test_client() as client:
+        _login(client, um)
+        html = client.get('/painel?ord=gmd_desc').get_data(as_text=True)
+
+    assert 'data-gmd-embutido="1"' in html
+    assert 'data-gmd="2.000"' in html
+
+
+def test_rota_painel_sem_ordenacao_nao_embute(app, trio):
+    um, _, _, _ = trio
+    with app.test_client() as client:
+        _login(client, um)
+        html = client.get('/painel').get_data(as_text=True)
+
+    # a marca é o atributo no <tbody>; a string crua também aparece no seletor
+    # do script inline, por isso a asserção casa o atributo com valor
+    assert 'data-gmd-embutido="1"' not in html
+    assert 'data-gmd=' not in html
+
+
+def test_rota_painel_ordenacao_invalida_nao_quebra(app, trio):
+    um, _, _, _ = trio
+    with app.test_client() as client:
+        _login(client, um)
+        r = client.get('/painel?ord=%27%20OR%201=1--')
+
+    assert r.status_code == 200
+
+
+def test_rota_painel_preserva_ordenacao_nos_links_de_filtro(app, trio):
+    """Trocar de filtro não pode derrubar a ordem escolhida (nem vice-versa)."""
+    um, _, _, _ = trio
+    with app.test_client() as client:
+        _login(client, um)
+        html = client.get('/painel?ord=peso_desc&status=ativos').get_data(as_text=True)
+
+    assert 'ord=peso_desc' in html
+    assert 'status=ativos' in html


### PR DESCRIPTION
A ordenação é feita no servidor, no mesmo query da paginação, e não no cliente: a lista vem paginada de 20 em 20 e o GMD nem está no HTML, então ordenar na tabela ordenaria apenas a página. Quem clica em "menor GMD" quer o pior boi da fazenda, não o pior entre os 20 que já vieram escolhidos por ordem de brinco — e o erro seria silencioso.

O parâmetro é um só (`ord=gmd_desc`, `peso_asc`, ...) contra uma whitelist no repositório: a chave vem da query string, o SQL é sempre literal, e estado inválido não é representável.

Ordenar por brinco (o padrão) continua sem tocar em `pesagens`. Só quem pede peso/GMD paga as CTEs de window function — e, nesse caso, os valores calculados para o ORDER BY já descem no HTML, o que dispensa a chamada a /api/animais/gmd-lote e evita a coluna ordenada aparecer em skeleton, fazendo a lista parecer fora de ordem.

Dois detalhes de correção no ORDER BY:

- `a.id` fecha todo critério. Sem coluna única, linhas empatadas (o bloco inteiro de gmd NULL) podem repetir numa página e sumir da seguinte.
- `<coluna> IS NULL` antes do critério joga os NULLs para o fim nos dois sentidos. No ASC puro do MySQL o NULL vem primeiro, e "menor GMD" abriria com animais de uma pesagem só em vez do pior boi medido.

O controle é um <select> na toolbar, não cabeçalho clicável: as colunas peso e GMD somem em tela estreita e no celular não sobraria cabeçalho para clicar. O botão "Aplicar" atende quem está sem JS e some quando o script assume. Os cabeçalhos ganharam aria-sort.

Fica também o template global `painel_url()`, que mescla request.args: cada link de filtro repassava busca/status/raça/origem/sexo na mão, e somar a ordenação a isso seria a sexta chance de esquecer um parâmetro e derrubar o filtro do usuário sem aviso.